### PR TITLE
Update puppet code for `profile::it::graylog` application on gs-graylog-node-01

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -41,7 +41,7 @@ mod 'puppet/python', '3.0.1'
 
 mod 'aboe/chrony', '0.2.5'
 mod 'crayfishx/firewalld', '3.4.0'
-mod 'elastic/elasticsearch', '6.3.3'
+mod 'elastic/elasticsearch', '6.4.0'
 mod 'elastic/elastic_stack', '6.3.1'
 mod 'golja/influxdb', '4.0.0'
 mod 'graylog/graylog', '0.8.0'

--- a/site/profile/manifests/default.pp
+++ b/site/profile/manifests/default.pp
@@ -58,10 +58,6 @@ class profile::default {
     ensure => installed,
   }
 
-  package { 'sudo':
-    ensure => installed,
-  }
-
 # Firewall and security measurements
 ################################################################################
 


### PR DESCRIPTION
This pull request updates the classes needed for gs-graylog-node-01 to use the `profile::it::graylog` class. This class was in use before the node was migrated to foreman, and having a little bit of Puppet management is better than no management at all.