### PR TITLE
dimm.cp.lsst.org: add ufw module

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -43,6 +43,7 @@ mod 'puppet/python', '3.0.1'
 mod 'attachmentgenie/ufw',
   git: 'https://github.com/attachmentgenie/attachmentgenie-ufw',
   commit: '58e0e9de'
+mod 'stm/debconf', '3.0.0'
 
 mod 'aboe/chrony', '0.2.5'
 mod 'crayfishx/firewalld', '3.4.0'

--- a/Puppetfile
+++ b/Puppetfile
@@ -39,6 +39,11 @@ mod 'puppetlabs/docker', '3.8.0'
 mod 'puppetlabs/reboot', '2.2.0'
 mod 'puppet/python', '3.0.1'
 
+# 2019-12-18 athebo: added for DIMM Ubuntu VM, we can remove this when the node is rebuilt
+mod 'attachmentgenie/ufw',
+  git: 'https://github.com/attachmentgenie/attachmentgenie-ufw',
+  commit: '58e0e9de'
+
 mod 'aboe/chrony', '0.2.5'
 mod 'crayfishx/firewalld', '3.4.0'
 mod 'elastic/elasticsearch', '6.4.0'


### PR DESCRIPTION
This adds the ufw module for dimm.cp.lsst.org, which is presently running Puppet.
This host will eventually be rebuilt (presumably using CentOS) so we should plan
on porting the ufw rules into firewalld when that switch happens.

Fixes IT-1536.