### PR TITLE
profile::core::common: add rsyslog class

### DIFF
--- a/site/profile/manifests/core/common.pp
+++ b/site/profile/manifests/core/common.pp
@@ -14,4 +14,6 @@ class profile::core::common {
   include ssh
   include easy_ipa
   include augeas
+  include rsyslog
+  include rsyslog::config
 }


### PR DESCRIPTION
This commit manages the rsyslog package and configuration for all corecp
nodes.