### PR TITLE
IT-1706: switch common layer to org layer

### DIFF
--- a/hiera.yaml
+++ b/hiera.yaml
@@ -17,7 +17,7 @@ hierarchy:
       - "role/%{role}/type/%{virtual}.yaml"
       - "type/%{virtual}.yaml"
       - "type/default.yaml"
-      - "common.yaml"
+      - "org/%{org}.yaml"
   - name: "public hiera"
     datadir: "/etc/puppetlabs/code/hieradata/public/%{environment}"
     paths:
@@ -32,4 +32,4 @@ hierarchy:
       - "role/%{role}/type/%{virtual}.yaml"
       - "type/%{virtual}.yaml"
       - "type/default.yaml"
-      - "common.yaml"
+      - "org/%{org}.yaml"


### PR DESCRIPTION
This commit switches the Hiera hierarchy to use organizational defaults
as the global layer, rather than a shared `common.yaml`. This change
ensures that we're deliberate about the scope of shared configuration
settings across NCSA and LSST.