### PR TITLE
IT-1686: add NFS module, nfs profile

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -38,6 +38,7 @@ mod 'puppetlabs/mailalias_core', '1.0.5'
 mod 'puppetlabs/docker', '3.8.0'
 mod 'puppetlabs/reboot', '2.2.0'
 mod 'puppet/python', '3.0.1'
+mod 'derdanne/nfs', '2.1.2'
 
 # 2019-12-18 athebo: added for DIMM Ubuntu VM, we can remove this when the node is rebuilt
 mod 'attachmentgenie/ufw',

--- a/site/profile/manifests/core/nfsclient.pp
+++ b/site/profile/manifests/core/nfsclient.pp
@@ -1,0 +1,8 @@
+class profile::core::nfsclient {
+  include nfs
+
+  $nfs_mounts = hiera_hash('nfs::client_mounts', false)
+  if $nfs_mounts {
+    create_resources('::nfs::client::mount', $nfs_mounts)
+  }
+}

--- a/site/profile/manifests/core/nfsserver.pp
+++ b/site/profile/manifests/core/nfsserver.pp
@@ -1,0 +1,8 @@
+class profile::core::nfsserver {
+  include nfs
+
+  $nfs_exports_global = hiera_hash('nfs::nfs_exports_global', false)
+  if $nfs_exports_global {
+    create_resources('::nfs::server::export', $nfs_exports_global)
+  }
+}


### PR DESCRIPTION
This pull request adds an NFS module for managing nfs exports and mounts, and
adds in some shims in our profile module to define NFS exports and mounts in
hiera.

I propose that we fork the derdanne/nfs module, apply some fixups, and inject
the hiera resource creation directly into the module. We can push these changes
upstream.