### PR TITLE
maint: flatten IPA hierarchy

### DIFF
--- a/hieradata/cluster/corecp/role/ipamaster.yaml
+++ b/hieradata/cluster/corecp/role/ipamaster.yaml
@@ -1,3 +1,0 @@
----
-easy_ipa::ipa_server_fqdn: "%{facts.fqdn}"
-easy_ipa::ip_address: "%{facts.networking.ip}"

--- a/hieradata/cluster/corecp/role/ipareplica.yaml
+++ b/hieradata/cluster/corecp/role/ipareplica.yaml
@@ -1,3 +1,0 @@
----
-easy_ipa::ipa_server_fqdn: "%{facts.fqdn}"
-easy_ipa::ip_address: "%{facts.networking.ip}"

--- a/hieradata/cluster/coretuc/role/ipamaster.yaml
+++ b/hieradata/cluster/coretuc/role/ipamaster.yaml
@@ -1,3 +1,0 @@
----
-easy_ipa::ipa_server_fqdn: "%{facts.fqdn}"
-easy_ipa::ip_address: "%{facts.networking.ip}"

--- a/hieradata/cluster/coretuc/role/ipareplica.yaml
+++ b/hieradata/cluster/coretuc/role/ipareplica.yaml
@@ -1,3 +1,0 @@
----
-easy_ipa::ipa_server_fqdn: "%{facts.fqdn}"
-easy_ipa::ip_address: "%{facts.networking.ip}"

--- a/hieradata/org/lsst/role/ipamaster.yaml
+++ b/hieradata/org/lsst/role/ipamaster.yaml
@@ -14,3 +14,5 @@ easy_ipa::install_epel: false
 easy_ipa::install_autofs: false
 easy_ipa::install_sssdtools: false
 easy_ipa::install_kstart: false
+easy_ipa::ipa_server_fqdn: "%{facts.fqdn}"
+easy_ipa::ip_address: "%{facts.networking.ip}"

--- a/hieradata/org/lsst/role/ipareplica.yaml
+++ b/hieradata/org/lsst/role/ipareplica.yaml
@@ -14,3 +14,5 @@ easy_ipa::install_epel: false
 easy_ipa::install_autofs: false
 easy_ipa::install_sssdtools: false
 easy_ipa::install_kstart: false
+easy_ipa::ipa_server_fqdn: "%{facts.fqdn}"
+easy_ipa::ip_address: "%{facts.networking.ip}"


### PR DESCRIPTION
We aren't doing anything interesting in the cluster specific IPA
configurations. This commit flattens them into the role definition.