### PR TITLE
maint: use a CNAME for the NTP server

### DIFF
--- a/hieradata/site/cp.yaml
+++ b/hieradata/site/cp.yaml
@@ -113,7 +113,7 @@ dhcp::nameservers: &nameservers
   - "139.229.162.87"  # dns2.cp.lsst.org
   - "208.67.222.222"  # resolver1.opendns.com
 dhcp::ntpservers: &ntpservers
-  - "139.229.167.1"
+  - "ntp.cp.lsst.org"
   - "ntp.shoa.cl"
   - "1.cl.pool.ntp.org"
   - "1.south-america.pool.ntp.org"

--- a/hieradata/site/ls.yaml
+++ b/hieradata/site/ls.yaml
@@ -69,7 +69,7 @@ dhcp::nameservers: &nameservers
   - "139.229.162.54"  # dns2.ls.lsst.org
   - "208.67.222.222"  # resolver1.opendns.com
 dhcp::ntpservers: &ntpservers
-  - "139.229.167.1"
+  - "ntp.cp.lsst.org"
   - "ntp.shoa.cl"
   - "1.cl.pool.ntp.org"
   - "1.south-america.pool.ntp.org"


### PR DESCRIPTION
We should prefer using DNS records over straight IP addresses as a
common convention so that we can migrate hosts between subnets, add
multiple A records for services that have multiple providers, redirect
services to a single host, etc.