### PR TITLE
Add "bash completion" and "bash completion extras"

### DIFF
--- a/hieradata/org/lsst/role/rke.yaml
+++ b/hieradata/org/lsst/role/rke.yaml
@@ -14,6 +14,8 @@ packages:
   - "kubectl"
   # convenience utils
   - "ack"
+  - "bash-completion"
+  - "bash-completion-extras"
   # debugging utils
   - "tcpdump"
   - "net-tools"


### PR DESCRIPTION
Add  bash completion module, and works for system native packages (such as systemctl, journalctl, ls....) but not for kubectl. In order for kubectl autocompletion to work we need to run "kubectl completion bash >/etc/bash_completion.d/kubectl". This is not complete and is going to be approach in the next PR.