### PR TITLE
IT-1860 general docker profile

### DIFF
--- a/hieradata/org/ncsa.yaml
+++ b/hieradata/org/ncsa.yaml
@@ -13,6 +13,13 @@ baseline_cfg::networkmanager::ensure: "running"
 
 chrony::leapsectz: "right/UTC"
 
+docker::overlay2_override_kernel_check: true
+docker::storage_driver: "overlay2"
+docker::version: "19.03.4"
+
+#epel::epel_baseurl: "http://lsst-repos01.ncsa.illinois.edu/centos/$releasever/$basearch/epel/2020-02-19-1582151101/"
+#epel::epel_exclude: "singularity*"
+
 profile::ncsa::allow_ssh_from_bastion::bastion_nodelist:
   - 10.142.181.15
   - 141.142.181.15
@@ -31,6 +38,16 @@ profile::ncsa::allow_ssh_from_login::allow_groups:
   - lsst_admin_ncsa
 
 profile::ncsa::allow_qualys_scan::ip: "141.142.148.51"
+
+python::dev: "present"
+python::pip: "present"
+python::python_pips:
+  "docker-compose":
+    virtualenv: "system"
+    ensure: "1.25.0"
+python::use_epel: false
+python::version: "python36"
+python::virtualenv: "present"
 
 rsyslog::use_upstream_repo: true
 rsyslog::feature_packages:

--- a/hieradata/org/ncsa/role/archiver.yaml
+++ b/hieradata/org/ncsa/role/archiver.yaml
@@ -1,0 +1,8 @@
+---
+classes:
+  - profile::docker
+  - profile::ncsa::allow_qualys_scan
+  - profile::ncsa::allow_ssh_from_login
+  - profile::ncsa::baseline_cfg
+  - profile::ncsa::system_authnz
+  - profile::ncsa::xcat_client

--- a/hieradata/site/npcf.yaml
+++ b/hieradata/site/npcf.yaml
@@ -1,5 +1,5 @@
 ---
-pakrat_client::default_snapshot: "2019-09-16-1568669101"
+pakrat_client::default_snapshot: "2020-02-19-1582151101"
 pakrat_client::default_yumserver_url: "http://lsst-repos01.ncsa.illinois.edu"
 pakrat_client::repos:
   base:

--- a/hieradata/site/nts.yaml
+++ b/hieradata/site/nts.yaml
@@ -1,5 +1,5 @@
 ---
-pakrat_client::default_snapshot: "2019-12-03-1575411902"
+pakrat_client::default_snapshot: "2020-02-19-1582151101"
 pakrat_client::default_yumserver_url: "http://lsst-repos01.ncsa.illinois.edu"
 pakrat_client::repos:
   base:

--- a/site/profile/manifests/docker.pp
+++ b/site/profile/manifests/docker.pp
@@ -1,0 +1,5 @@
+# Docker and Docker-compose
+class profile::docker {
+  include ::docker
+  include ::python
+}


### PR DESCRIPTION
Create a generic docker profile
```
profile::docker
```
that can be included in any role. This is essentially a copy of:
```
hieradata/org/lsst/role/docker-compose.yaml
```
that splits the `include`s into the profile and the data into hiera.