### PR TITLE
IT-1954: set default rsyslog client log actions

### DIFF
--- a/hieradata/org/lsst.yaml
+++ b/hieradata/org/lsst.yaml
@@ -124,6 +124,47 @@ rsyslog::config::modules:
   immark: {}
   imfile: {}
 
+rsyslog::config::actions:
+  # Log anything (except mail) of level info or higher.
+  # Don't log private authentication messages!
+  #
+  # local6 is used for logs that should only be forwarded to a central log
+  # server and should never be stored locally. See IT-1734.
+  messages:
+    type: "omfile"
+    facility: "*.info;mail.none;authpriv.none;cron.none;local6.none"
+    config:
+      file: "/var/log/messages"
+  # The authpriv file has restricted access.
+  secure:
+    type: "omfile"
+    facility: "authpriv.*"
+    config:
+      file: "/var/log/secure"
+  # Everybody gets emergency messages
+  emerg:
+    type: "omusrmsg"
+    facility: "*.emerg"
+    config:
+      users: "*"
+  maillog:
+    type: "omfile"
+    facility: "mail.*"
+    config:
+      file: "-/var/log/maillog"
+  cron:
+    type: "omfile"
+    facility: "cron.*"
+    config:
+      file: "/var/log/cron"
+  # local7 does not appear to be used by CentOS 7, but for the sake of
+  # consistency we preserve it to match the CentOS configuration.
+  boot:
+    type: "omfile"
+    facility: "local7.*"
+    config:
+      file: "-/var/log/boot.log"
+
 yum::plugin::versionlock:
   # trigger `yum clean all`
   clean: true


### PR DESCRIPTION
In 125707a we pushed the global rsyslog configuration to the LSST
organization level which rewrote the tucson rsyslog.conf files, but we
didn't add client actions, which disabled logging to /var/log/* at
Tucson. This commit resolves the issue by pushing default configuration
at the organziation level; this configuration will be overridden on a
site-specific basis.