### PR TITLE
IT-1454: regenerate types when r10k deploys modules

### DIFF
--- a/hieradata/org/lsst/role/foreman.yaml
+++ b/hieradata/org/lsst/role/foreman.yaml
@@ -34,3 +34,5 @@ r10k::webhook::config::protected: false
 r10k::webhook::use_mcollective: false
 r10k::webhook::user: "root"
 r10k::webhook::group: "root"
+r10k::deploy_settings:
+  generate_types: true


### PR DESCRIPTION
Puppet uses abstract type definitions to prevent types from leaking between
different Puppet environments, but require an additional generation step for
them to be loadable by Puppet. This modifies r10k to perform that regeneration
when deploying an environment.