### PR TITLE
IT-1480: reimplement telegraf

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -63,9 +63,12 @@ mod 'puppetlabs/vcsrepo', '3.0.0'
 mod 'puppet/mongodb', '3.1.0'
 mod 'puppet/rsyslog', '4.0.0'
 mod 'puppet/ssh_keygen', '4.0.0'
-# This requires toml/rb which has to be manually installed - should only happen
-# on the puppet master
-mod 'puppet/telegraf', '2.1.0'
+
+# This requires toml-rb, which should be installed on the puppet master.
+# @see profile::core::puppet_master
+mod 'puppet/telegraf', '3.0.0'
+mod 'puppetlabs-puppetserver_gem', '1.1.1'
+
 mod 'puppet/yum', '4.0.0'
 mod 'richardc/datacat', '0.6.2'
 mod 'stahnma/epel', '1.3.1'

--- a/hieradata/node/gs-telegraf-node-01.cp.lsst.org.yaml
+++ b/hieradata/node/gs-telegraf-node-01.cp.lsst.org.yaml
@@ -2,11 +2,16 @@
 classes:
   - "profile::core::common"
   - "profile::it::monitoring"
+
+# Disable standard host level monitoring on this node, it's using the legacy
+# `profile::it::monitoring` module.
+profile::core::common::collect_metrics: false
+
 telegraf::inputs:
   snmp:
     - agents:
         - "139.229.162.122"  # Auxtel UPS
-        - "139.229.162.126"
+        - "139.229.162.126"  # Computer room router - provides computer room temp monitoring.
       community: "lsst_network"
       version: 1
       field:

--- a/site/profile/manifests/core/common.pp
+++ b/site/profile/manifests/core/common.pp
@@ -1,3 +1,5 @@
+# @summary
+#   Common functionality needed by standard nodes.
 class profile::core::common {
   include timezone
   include tuned

--- a/site/profile/manifests/core/common.pp
+++ b/site/profile/manifests/core/common.pp
@@ -1,6 +1,13 @@
 # @summary
 #   Common functionality needed by standard nodes.
-class profile::core::common {
+#
+# @param collect_metrics
+#   Enable or disable metrics collection. Metrics collection may be disabled on development
+#   nodes, nodes that don't have uptime requirements, or nodes that should only have minimal
+#   software load.
+class profile::core::common(
+  Boolean $collect_metrics = true,
+) {
   include timezone
   include tuned
   include chrony
@@ -18,5 +25,8 @@ class profile::core::common {
   include augeas
   include rsyslog
   include rsyslog::config
-  include profile::core::telegraf
+
+  if $collect_metrics {
+    include profile::core::telegraf
+  }
 }

--- a/site/profile/manifests/core/common.pp
+++ b/site/profile/manifests/core/common.pp
@@ -16,4 +16,5 @@ class profile::core::common {
   include augeas
   include rsyslog
   include rsyslog::config
+  include profile::core::telegraf
 }

--- a/site/profile/manifests/core/puppet_master.pp
+++ b/site/profile/manifests/core/puppet_master.pp
@@ -55,4 +55,12 @@ class profile::core::puppet_master(
     enable    => true,
     subscribe => Exec['install-smee'],
   }
+
+  # The toml-rb gem is required for the telegraf module.
+  #
+  # Note that if the telegraf module is used then Puppet will fail during a catalog
+  # compilation, so we might need to manually install this gem in that scenario.
+  package { 'toml-rb':
+    provider => 'puppetserver_gem',
+  }
 }

--- a/site/profile/manifests/core/telegraf.pp
+++ b/site/profile/manifests/core/telegraf.pp
@@ -12,26 +12,22 @@
 #
 # @param host
 #   The backing InfluxDB instance. At present the default DNS record is a CNAME.
-#
-# @param port
-#   The backing InfluxDB port.
 class profile::core::telegraf(
   String $password,
   String $username = 'telegraf-nodes',
   String $database = 'nodes',
   String $host     = 'metrics-ingress.ls.lsst.org',
-  String $port     = '8086'
 ) {
   class { '::telegraf':
     hostname    => $::facts['fqdn'],
-    global_tags => {"site" => $::site},
+    global_tags => {'site' => $::site},
   }
 
   $default_inputs = {
     'cpu'        => [{}],
     'chrony'     => [{}],
     'conntrack'  => [{}],
-    'disk'       => [{"ignore_fs" => ["tmpfs", "devtmpfs", "overlay"]}],
+    'disk'       => [{'ignore_fs' => ['tmpfs', 'devtmpfs', 'overlay']}],
     'diskio'     => [{}],
     'interrupts' => [{}],
     'mem'        => [{}],
@@ -49,8 +45,8 @@ class profile::core::telegraf(
     }
   }
 
-  $influxdb_url = "http://${host}:${port}"
-  telegraf::output { 'chile-influxdb':
+  $influxdb_url = "http://${host}:8086"
+  telegraf::output { 'metrics-ingress':
     plugin_type => 'influxdb',
     options     => [
       {

--- a/site/profile/manifests/core/telegraf.pp
+++ b/site/profile/manifests/core/telegraf.pp
@@ -1,3 +1,20 @@
+# @summary
+#   Monitor system metrics.
+#
+# @param password
+#   The InfluxDB password for the telegraf user
+#
+# @param username
+#   The InfluxDB username for node metrics (as opposed to summit power metrics).
+#
+# @param database
+#   The InfluxDB database for node metrics (as opposed to summit power metrics).
+#
+# @param host
+#   The backing InfluxDB instance. At present the default DNS record is a CNAME.
+#
+# @param port
+#   The backing InfluxDB port.
 class profile::core::telegraf(
   String $password,
   String $username = 'telegraf-nodes',

--- a/site/profile/manifests/core/telegraf.pp
+++ b/site/profile/manifests/core/telegraf.pp
@@ -1,0 +1,47 @@
+class profile::core::telegraf(
+  String $password,
+  String $username = 'telegraf-nodes',
+  String $database = 'nodes',
+  String $host     = 'metrics-ingress.ls.lsst.org',
+  String $port     = '8086'
+) {
+  class { '::telegraf':
+    hostname    => $::facts['fqdn'],
+    global_tags => {"site" => $::site},
+  }
+
+  $default_inputs = {
+    'cpu'        => [{}],
+    'chrony'     => [{}],
+    'conntrack'  => [{}],
+    'disk'       => [{"ignore_fs" => ["tmpfs", "devtmpfs", "overlay"]}],
+    'diskio'     => [{}],
+    'interrupts' => [{}],
+    'mem'        => [{}],
+    'net'        => [{}],
+    'netstat'    => [{}],
+    'processes'  => [{}],
+    'system'     => [{}],
+    'swap'       => [{}],
+  }
+
+  $default_inputs.each |$type, $options| {
+    telegraf::input { $type:
+      plugin_type => $type,
+      options     => $options
+    }
+  }
+
+  $influxdb_url = "http://${host}:${port}"
+  telegraf::output { 'chile-influxdb':
+    plugin_type => 'influxdb',
+    options     => [
+      {
+        'urls'     => [$influxdb_url],
+        'database' => $database,
+        'username' => $username,
+        'password' => $password
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This pull request reimplements telegraf as a monitoring agent on Puppet hosts.

TODO:

* [x] Ensure that this change won't impact the summit monitoring servers
* [x] Figure out how we'll selectively enable this on sites that have influx servers