### PR TITLE
IT-2081: Install ipmitool on all poweredge servers

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -38,6 +38,7 @@ mod 'puppetlabs/docker', '3.8.0'
 mod 'puppetlabs/reboot', '2.2.0'
 mod 'puppet/python', '3.0.1'
 mod 'derdanne/nfs', '2.1.2'
+mod 'jhoblitt/ipmi', '2.3.0'
 
 # 2019-12-18 athebo: added for DIMM Ubuntu VM, we can remove this when the node is rebuilt
 mod 'attachmentgenie/ufw',

--- a/site/profile/manifests/core/common.pp
+++ b/site/profile/manifests/core/common.pp
@@ -25,6 +25,7 @@ class profile::core::common(
   include augeas
   include rsyslog
   include rsyslog::config
+  include profile::core::hardware
 
   if $collect_metrics {
     include profile::core::telegraf

--- a/site/profile/manifests/core/hardware.pp
+++ b/site/profile/manifests/core/hardware.pp
@@ -1,0 +1,13 @@
+# @summary
+#   Manage packages and services needed on different hardware platforms.
+class profile::core::hardware {
+
+  # lint:ignore:case_without_default
+  case $facts.dig('dmi', 'product', 'name') {
+    /PowerEdge/: {
+      include ipmi
+      # LLDP will be added in the future
+    }
+  }
+  # lint:endignore
+}


### PR DESCRIPTION
This pull request installs ipmitool on hardware that has an IPMI
implementation. For now this is restricted to PowerEdge servers but can expand
as additional server manufacturers are used.