### PR TITLE
maint: remove ipmitool from RKE profile

### DIFF
--- a/hieradata/org/lsst/role/rke.yaml
+++ b/hieradata/org/lsst/role/rke.yaml
@@ -12,7 +12,6 @@ classes:
   - "yum"
 packages:
   - "kubectl"
-  - "ipmitool"
   - "git"
   - "gdisk"
   # convenience utils


### PR DESCRIPTION
`ipmitool` is automatically installed on all poweredge servers by
default in profile::core::hardware.