### PR TITLE
IT-2002 grant NTS access to L1 users

### DIFF
--- a/hieradata/org/ncsa.yaml
+++ b/hieradata/org/ncsa.yaml
@@ -8,6 +8,11 @@ lookup_options:
 
 # Everything else should be sorted alphabetically
 
+baseline_cfg::additional_packages::pkg_list:
+  RedHat:
+    tcsh:
+    zsh:
+
 baseline_cfg::networkmanager::enable: true
 baseline_cfg::networkmanager::ensure: "running"
 

--- a/hieradata/site/nts.yaml
+++ b/hieradata/site/nts.yaml
@@ -48,6 +48,9 @@ pakrat_client::repos:
     # if we use GPG key checking, it's probably because we have only CentOS-built RPMs in the repo
     gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7"
 
+profile::ncsa::allow_ssh_from_login::allow_groups:
+  - lsst_level1_adm
+
 rsyslog::client::actions:
   ncsa_security_loghost:
     type: "omrelp"


### PR DESCRIPTION
- Allow LDAP group lsst_level1_adm to login to NTS hosts from login nodes
- Install csh (default in LDAP) and zsh (common enough to include in baseline)