### PR TITLE
maint: remove obsolete geppetto settings

### DIFF
--- a/.settings/com.puppetlabs.geppetto.pp.dsl.PP.prefs
+++ b/.settings/com.puppetlabs.geppetto.pp.dsl.PP.prefs
@@ -1,3 +1,0 @@
-com.puppetlabs.geppetto.pp.dsl.PP.searchPath.useProjectSettings=true
-eclipse.preferences.version=1
-puppetPath=site/*\:lib/*\:environments/$environment/*\:$manifestdir/*\:modules/*\:


### PR DESCRIPTION
Geppetto was an Eclipse based IDE for Puppet and has been deprecated for
years. This commit removes configuration needed for that editor.