### PR TITLE
maint: don't create influx telegraf database

### DIFF
--- a/site/profile/manifests/core/telegraf.pp
+++ b/site/profile/manifests/core/telegraf.pp
@@ -50,10 +50,11 @@ class profile::core::telegraf(
     plugin_type => 'influxdb',
     options     => [
       {
-        'urls'     => [$influxdb_url],
-        'database' => $database,
-        'username' => $username,
-        'password' => $password
+        'urls'                   => [$influxdb_url],
+        'database'               => $database,
+        'username'               => $username,
+        'password'               => $password,
+        'skip_database_creation' => true
       }
     ]
   }


### PR DESCRIPTION
The telegraf user can only write to the "telegraf" database and doesn't have
rights to create the DB.