### PR TITLE
maint: remove conntrack plugin from telegraf

### DIFF
--- a/site/profile/manifests/core/telegraf.pp
+++ b/site/profile/manifests/core/telegraf.pp
@@ -39,7 +39,6 @@ class profile::core::telegraf(
   $default_inputs = {
     'cpu'        => [{}],
     'chrony'     => [{}],
-    'conntrack'  => [{}],
     'disk'       => [{'ignore_fs' => ['tmpfs', 'devtmpfs', 'overlay']}],
     'diskio'     => [{}],
     'interrupts' => [{}],


### PR DESCRIPTION
The conntrack kernel module isn't loaded on all of our nodes and at
present we don't have a need to monitor conntrack statistics. This
commit drops the input plugin from telegraf; we can re-add it when we
need it.