### PR TITLE
IT-2104: remove unmanaged telegraf inputs and outputs

### DIFF
--- a/site/profile/manifests/core/telegraf.pp
+++ b/site/profile/manifests/core/telegraf.pp
@@ -20,9 +20,10 @@ class profile::core::telegraf(
 ) {
   $influxdb_url = "http://${host}:8086"
   class { '::telegraf':
-    hostname    => $::facts['fqdn'],
-    global_tags => {'site' => $::site},
-    outputs     => {
+    hostname               => $::facts['fqdn'],
+    global_tags            => {'site' => $::site},
+    purge_config_fragments => true,
+    outputs                => {
       'influxdb' => [
         {
           'urls'                   => [$influxdb_url],


### PR DESCRIPTION
By default the telegraf module doesn't purge unmanaged plugin
configurations in `/etc/telegraf/telegraf.d`. This commit reconfigures
the telegraf module to purge unmanaged configs so that deleting a
plugin from Puppet will remove the plugin.