### PR TITLE
manage DAQ network dhcpd

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -18,7 +18,9 @@ mod 'puppetlabs/git', '0.5.0'
 mod 'puppetlabs/ruby', '1.0.1'
 mod 'camptocamp/systemd', '2.6.0'
 mod 'bodgit/scl', '1.0.1'
-mod 'theforeman/dhcp', '5.1.1'
+mod 'theforeman/dhcp',
+  git: 'https://github.com/lsst-it/puppet-dhcp',
+  ref: 'c9304257d4a800008baa3406e453fc9393faf7b7'
 mod 'theforeman/dns', '6.2.0'
 mod 'duritong/sysctl', '0.0.12'
 mod 'example42/network', '3.5.1'

--- a/hieradata/org/lsst/role/comcam-fp.yaml
+++ b/hieradata/org/lsst/role/comcam-fp.yaml
@@ -2,8 +2,25 @@
 classes:
   - "profile::core::common"
   - "profile::ccs::postfix"
+  - "dhcp"
 # enable ntp server for DAQ
 chrony::port: 123
 chrony::queryhosts:
   - "192.168.100/24"
 chrony::clientlog: true
+
+# dhcp for DAQ + clients
+dhcp::interfaces:
+  - "lsst-daq"
+dhcp::bootp: true
+dhcp::logfacility: "local7"
+dhcp::pools:
+  daq_clients:
+    network: "192.168.100.0"
+    mask: "255.255.255.0"
+    range: "192.168.100.2 192.168.100.254"
+    pool_parameters:
+      - "authoritative"
+      - "ddns-update-style none"
+      - "default-lease-time -1"
+      - "max-lease-time -1"

--- a/hieradata/site/ls/role/comcam-fp.yaml
+++ b/hieradata/site/ls/role/comcam-fp.yaml
@@ -1,0 +1,4 @@
+---
+dhcp::dnsdomain: [] # ignore site value & mod default
+dhcp::nameservers: ~ # ignore site value
+dhcp::ntpservers: ~ # ignore site value


### PR DESCRIPTION
```
Notice: /Stage[main]/Dhcp/Concat[/etc/dhcp/dhcpd.conf]/File[/etc/dhcp/dhcpd.conf]/content: 
--- /etc/dhcp/dhcpd.conf	2019-10-08 17:00:28.427861509 +0000
+++ /tmp/puppet-file20200430-413113-1o2zor8	2020-04-30 20:41:57.030150545 +0000
@@ -1,8 +1,16 @@
 # dhcpd.conf
-
 omapi-port 7911;
 
-log-facility local7;
+default-lease-time 43200;
+max-lease-time 86400;
+
+
+not authoritative;
+
+
+ddns-update-style none;
+
+option ntp-servers none;
 
 allow booting;
 allow bootp;
@@ -11,39 +19,23 @@
 option fqdn.rcode2            255;
 option pxegrub code 150 = text ;
 
-# Bootfile Handoff
-#option architecture code 93 = unsigned integer 16 ;
-#if option architecture = 00:06 {
-#  filename "grub2/shim.efi";
-#} elsif option architecture = 00:07 {
-#  filename "grub2/shim.efi";
-#} elsif option architecture = 00:09 {
-#  filename "grub2/shim.efi";
-#} else {
-#  filename "pxelinux.0";
-#}
 
-include "/etc/dhcp/dhcpd.hosts";
-# test
-#subnet 10.0.103.0 netmask 255.255.255.0 {
-#  default-lease-time 43200;
-#  max-lease-time 86400;
-#  not authoritative;
-#  ddns-update-style none;
-#  option domain-name "test";
-#  option domain-name-servers 10.0.103.101;
-#  next-server 10.0.103.101;
-#  option ntp-servers none;
-#  range 10.0.103.102 10.0.103.106;
-#  option subnet-mask 255.255.255.0;
-#  option routers 10.0.103.1;
-#}
 
-# Reserve 192.168.100.1 for this machine                                                                                                           
+
+
+log-facility local7;
+
+include "/etc/dhcp/dhcpd.hosts";
+# daq_clients
 subnet 192.168.100.0 netmask 255.255.255.0 {
-  range 192.168.100.2 192.168.100.254;
-  authoritative;
-  ddns-update-style none;
-  default-lease-time -1;
-  max-lease-time -1;
+  pool
+  {
+    authoritative;
+    ddns-update-style none;
+    default-lease-time -1;
+    max-lease-time -1;
+    range 192.168.100.2 192.168.100.254;
+  }
+
+  option subnet-mask 255.255.255.0;
 }

```