### PR TITLE
add comcam-sm interface/hosts to comcam-fp01

### DIFF
--- a/hieradata/node/comcam-fp01.ls.lsst.org.yaml
+++ b/hieradata/node/comcam-fp01.ls.lsst.org.yaml
@@ -1,8 +1,23 @@
 ---
 classes:
   - "profile::ccs::daq_interface"
+  - "network"
+  - "hosts"
 
 profile::ccs::daq_interface::hwaddr: "b4:96:91:4d:d2:5c"
 profile::ccs::daq_interface::uuid: "995511a3-a10e-490d-b65e-c0e40fc3e233"
 profile::ccs::daq_interface::was: "p1p1"
 profile::ccs::daq_interface::mode: "dhcp-server"
+
+network::interfaces_hash:
+  em2:  # comcam-sm
+    bootproto: "none"
+    defroute: "no"
+    ipaddress: &ip "10.0.0.1"
+    ipv6init: "no"
+    netmask: "255.255.255.0"
+    onboot: "yes"
+    type: "Ethernet"
+hosts::host_entries:
+  "comcam-sm":
+    ip: *ip

--- a/hieradata/site/ls/role/comcam-fp.yaml
+++ b/hieradata/site/ls/role/comcam-fp.yaml
@@ -1,4 +1,4 @@
 ---
-dhcp::dnsdomain: [] # ignore site value & mod default
-dhcp::nameservers: ~ # ignore site value
-dhcp::ntpservers: ~ # ignore site value
+dhcp::dnsdomain: []  # ignore site value & mod default
+dhcp::nameservers: ~  # ignore site value
+dhcp::ntpservers: ~  # ignore site value

--- a/site/profile/manifests/ccs/daq_interface.pp
+++ b/site/profile/manifests/ccs/daq_interface.pp
@@ -24,7 +24,7 @@ class profile::ccs::daq_interface(
   network::interface { $interface:
     defroute => 'no',  # this was yes on comcam-fp01
     hwaddr   => $hwaddr,
-    ipv6init => false,
+    ipv6init => 'no',
     onboot   => true,
     type     => 'Ethernet',
     uuid     => $uuid,


### PR DESCRIPTION
```
--- /etc/sysconfig/network-scripts/ifcfg-em2	2019-07-31 16:53:26.914856726 +0000
+++ /tmp/puppet-file20200501-41574-1325zdt	2020-05-01 19:57:23.406035275 +0000
@@ -1,18 +1,11 @@
-TYPE=Ethernet
-PROXY_METHOD=none
-BROWSER_ONLY=no
-BOOTPROTO=none
-DEFROUTE=yes
-IPV4_FAILURE_FATAL=no
-IPADDR=10.0.0.1
-PREFIX=24
-IPV6INIT=no
-IPV6_AUTOCONF=no
-IPV6_DEFROUTE=no
-IPV6_FAILURE_FATAL=no
-IPV6_ADDR_GEN_MODE=stable-privacy
-NAME=em2
-UUID=45e47725-021d-4808-9fbe-3d4978528bb6
-DEVICE=em2
-ONBOOT=yes
-
+# File Managed by Puppet
+DEVICE="em2"
+BOOTPROTO="none"
+ONBOOT="yes"
+TYPE="Ethernet"
+USERCTL="no"
+PEERDNS="no"
+PEERNTP="no"
+IPADDR="10.0.0.1"
+DEFROUTE="no"
+IPV6INIT="no"

```