### PR TITLE
IT-2206 add profile::ncsa::allow_sudo

### DIFF
--- a/hieradata/org/ncsa.yaml
+++ b/hieradata/org/ncsa.yaml
@@ -74,6 +74,8 @@ pakrat_client::repos:
     # if we use GPG key checking, it's probably because we have only CentOS-built RPMs in the repo
     gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7"
 
+profile::ncsa::allow_qualys_scan::ip: "141.142.148.51"
+
 profile::ncsa::allow_ssh_from_bastion::bastion_nodelist:
   - 10.142.181.15
   - 141.142.181.15
@@ -91,7 +93,8 @@ profile::ncsa::allow_ssh_from_login::login_nodelist:
 profile::ncsa::allow_ssh_from_login::allow_groups:
   - lsst_admin_ncsa
 
-profile::ncsa::allow_qualys_scan::ip: "141.142.148.51"
+profile::ncsa::allow_sudo::groups:
+  - lsst_admin_ncsa
 
 python::dev: "present"
 python::pip: "present"
@@ -331,8 +334,8 @@ sssd::services:
       - wireshark
   pam: {}
 
+# Default sudo setup
 sudo::configs:
-  # Defaults should probably move to common.yaml
   defaults:
     priority: 0
     content:
@@ -354,17 +357,9 @@ sudo::configs:
       - '%all_disabled_usr ALL=(ALL) !ALL'
       - '#deny users in lsst_disabled LDAP group'
       - '%lsst_disabled ALL=(ALL) !ALL'
-  common_lsst_admins:
-    priority: 10
-    content:
-      - '%lsst_admin_ncsa ALL=(ALL) NOPASSWD: ALL'
 
 sudo::content: "system_authnz/sudoers.erb"
 
-system_authnz::access::access_allow:
-  'Allow group lsst_admin_ncsa from ALL':
-    group: "lsst_admin_ncsa"
-    origin: "ALL"
 system_authnz::access::access_deny_before:
   'Deny group lsst_disabled from ALL':
     group: "lsst_disabled"

--- a/hieradata/org/ncsa/role/default.yaml
+++ b/hieradata/org/ncsa/role/default.yaml
@@ -1,6 +1,7 @@
 ---
 classes:
   - profile::ncsa::allow_qualys_scan
+  - profile::ncsa::allow_ssh_from_bastion
   - profile::ncsa::allow_ssh_from_login
   - profile::ncsa::baseline_cfg
   - profile::ncsa::system_authnz

--- a/hieradata/site/npcf/cluster/deploy-test.yaml
+++ b/hieradata/site/npcf/cluster/deploy-test.yaml
@@ -1,8 +1,6 @@
+---
 profile::ncsa::allow_ssh_from_login::allow_groups:
   - "lsst_level1_adm"
 
-sudo::configs:
-  npcf_cluster_deploy_test:
-    priority: 20
-    content:
-      - "%lsst_level1_adm ALL=(ALL) NOPASSWD: ALL"
+profile::ncsa::allow_sudo::groups:
+  - "lsst_level1_adm"

--- a/site/profile/data/common.yaml
+++ b/site/profile/data/common.yaml
@@ -5,6 +5,10 @@ lookup_options:
     merge: "unique"
   profile::ncsa::allow_ssh_from_bastion::allow_groups:
     merge: "unique"
+  profile::ncsa::allow_sudo::groups:
+    merge: "unique"
+  profile::ncsa::allow_sudo::users:
+    merge: "unique"
 
 # Everything else goes down below. Sort keys alphabetically
 

--- a/site/profile/manifests/ncsa/allow_sudo.pp
+++ b/site/profile/manifests/ncsa/allow_sudo.pp
@@ -1,0 +1,59 @@
+# @summary Allow sudo access for users and/or groups
+#          Configures sudoers and access.conf
+#
+# @param
+#   users
+#   Type: Array
+#   Desc: one or more LDAP / UNIX users that are allowed sudo access
+#   Note: can be empty
+#
+# @param
+#   groups
+#   Type: Array
+#   Desc: one or more LDAP / UNIX groups that are allowed to login from
+#   Note: can be empty
+#
+# @example
+#   include profile::ncsa::allow_sudo
+#
+class profile::ncsa::allow_sudo (
+    Array[ String ] $users  = [],
+    Array[ String ] $groups = [],
+) {
+
+    # Validate Input
+    if empty( $users ) and empty( $groups ) {
+        fail( "'users' and 'groups' cannot both be empty" )
+    }
+
+    # GROUPS
+    $groups.each |String $group| {
+
+        sudo::conf { "sudo for group ${group}":
+            content  => "%${group} ALL=(ALL) NOPASSWD: ALL",
+        }
+
+        pam_access::entry { "Allow sudo for group ${group}":
+            group      => $group,
+            origin     => 'LOCAL',
+            permission => '+',
+            position   => '-1',
+        }
+    }
+
+    # USERS
+    $users.each |String $user| {
+
+        sudo::conf { "sudo for user ${user}":
+            content => "%${user} ALL=(ALL) NOPASSWD: ALL",
+        }
+
+        pam_access::entry { "Allow sudo for user ${user}":
+            user       => $user,
+            origin     => 'LOCAL',
+            permission => '+',
+            position   => '-1',
+        }
+    }
+
+}

--- a/site/profile/manifests/ncsa/system_authnz.pp
+++ b/site/profile/manifests/ncsa/system_authnz.pp
@@ -4,9 +4,8 @@
 #   include profile::system_authnz
 class profile::ncsa::system_authnz {
 
+    include ::profile::ncsa::allow_sudo
     include ::system_authnz
     include ::sshd
     include ::sssd
-    include ::sudo   # saz::sudo
-
 }


### PR DESCRIPTION
Add profile::ncsa::allow_sudo
...combines setup for access.conf and sudoers in one place

Move lsst_admin_ncsa sudo access to use profile::ncsa::allow_sudo
...was in sudo::configs (global content)

Remove lsst_admin_ncsa from system_authnz::access::access_allow
...will now be taken care of by profile::ncsa::allow_sudo

Allow_sudo access for lsst_level1_adm on nodes in deploy-test cluster

Allow ssh from bastion in default role