### PR TITLE
initial comcam-arctl role

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,12 @@
+.DS_Store
 /bin/
-Gemfile.lock
 /.bundle/
 /convert_report.txt
 /coverage/
 /doc/
 .envrc
 /Gemfile.local
+Gemfile.lock
 .git/
 /.idea/
 *.iml
@@ -13,6 +14,7 @@ Gemfile.lock
 /junit/
 /log/
 .metadata
+/modules
 /pkg/
 .project
 /spec/fixtures/manifests/
@@ -24,4 +26,3 @@ Gemfile.lock
 /vendor/
 .yardoc
 .yardwarns
-/modules

--- a/Puppetfile
+++ b/Puppetfile
@@ -42,6 +42,7 @@ mod 'puppet/python', '3.0.1'
 mod 'derdanne/nfs', '2.1.2'
 mod 'jhoblitt/ipmi', '2.3.0'
 mod 'puppet/lldpd', '2.2.0'
+mod 'puppet/rabbitmq', '10.0.1'
 
 # 2019-12-18 athebo: added for DIMM Ubuntu VM, we can remove this when the node is rebuilt
 mod 'attachmentgenie/ufw',

--- a/Puppetfile
+++ b/Puppetfile
@@ -43,6 +43,7 @@ mod 'derdanne/nfs', '2.1.2'
 mod 'jhoblitt/ipmi', '2.3.0'
 mod 'puppet/lldpd', '2.2.0'
 mod 'puppet/rabbitmq', '10.0.1'
+mod 'puppet/redis', '6.0.0'
 
 # 2019-12-18 athebo: added for DIMM Ubuntu VM, we can remove this when the node is rebuilt
 mod 'attachmentgenie/ufw',

--- a/hieradata/org/lsst.yaml
+++ b/hieradata/org/lsst.yaml
@@ -71,8 +71,6 @@ lookup_options:
 accounts::group_list:
   wheel_b: {}
 accounts::user_defaults:
-  groups:
-    - "wheel_b"
   managehome: true
   system: false
   managevim: false
@@ -80,12 +78,18 @@ accounts::user_list:
   root:
     password: "%{root_pw}"
   jhoblitt_b:  # backup access in case LDAP fails
+    groups:
+      - "wheel_b"
     sshkeys:
       - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDZFV9AL2qPh6CV+DeY32oyg0jCkxkbCHVSPHOoikDkwzwMW/7QQdRI8TJ0h8vpFi15pNyu+n7s7MJSWdg5yUvTCataVpOndDElDz10DaEcGIHNq8/qjEPiHulj/KUoDkEU+yMoWY8jRs3ARyL+6p6LDUBsWpzIY8jMOaEVUJjlVt+0ih2a/D3re0daws6w3mBbmLjitHLS5f2YJKlStIHWCWjMXvP5tqUsvhHvIQH/csBQGXnUiRxR8YSJK9u3CMvTzx6PnC7p98yRCOOrMRQ7yT7vuXyXsk7qoUpArUe/T5nEcwRA/21QVurJ1s3in/mpFI0Ogg5kD7NpFqoTq6itBxbPz7DwaOyjEltJBjQAEvuvfHDJYsBTM3fpfEt5jR8ieuDta1214tr5qVOmR17JonssV7/ksizATm1KkMA7+Q8CWCgrFdZmEMaFjav2U72EWyLRe5utxQV+dWPnxd13NxVu6sgM3CBEC4HzOBMf+upt8tMvjLBjci1sbhCAvvU= github2"
   athebo_b:  # backup access in case LDAP fails
+    groups:
+      - "wheel_b"
     sshkeys:
       - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIE8XVjITG6l2q37rDrL037aB2vDr0HsdXAl1ffmhj9TK adrien@faraday"
   hreinking_b:  # backup access in case LDAP fails
+    groups:
+      - "wheel_b"
     sshkeys:
       - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn8ssc5uxsHRdhvykrrQWiDMLzpjH/GC2011SyQBpBS43grDpxpGXXSL28LTMRxw3TZhAL4F1szLWR0O7kmKwTcK5OyF/7X/qvZ+w8ZtOxIU/FsSWEXbG2wrkX7fT+SvF/1WS97cu/EacjmFdQUQyYwPcF3MvmBMp3Hk1eSgJA97I7dUiUJjPda2iNFCnaTW9yJIUYfBPvXeO2FePzCUp8ImBZSkst/VLMTrTQ9DFB+Aj0E8npet8JFn2pUxG198yS2MH7tr3s9XKCUcpUXqySQNwIbtNsEKXljpxpQ3ftcaxo3fw0tgjdBr5BDjrBXbVsw+eVz3vwT7GvGHCGTeDP hreinking@NBB40230-1-A.local"
   lssttech:

--- a/hieradata/org/lsst/role/comcam-arctl.yaml
+++ b/hieradata/org/lsst/role/comcam-arctl.yaml
@@ -39,4 +39,4 @@ python::python_pips:
     ensure: "1.25.0"
   "redis":
     virtualenv: "system"
-    ensure: "3.2.1"
+    ensure: "3.5.1"

--- a/hieradata/org/lsst/role/comcam-arctl.yaml
+++ b/hieradata/org/lsst/role/comcam-arctl.yaml
@@ -1,6 +1,6 @@
 ---
 classes:
   - "profile::core::common"
-  - "rabbitmq"
+  - "profile::archive::rabbitmq"
 rabbitmq::admin_enable: true
 rabbitmq::management_enable: true

--- a/hieradata/org/lsst/role/comcam-arctl.yaml
+++ b/hieradata/org/lsst/role/comcam-arctl.yaml
@@ -66,6 +66,7 @@ redis::bind: "127.0.0.1"
 redis::manage_repo: true
 redis::scl: true
 redis::globals::scl: "rh-redis5"
+redis::package_ensure: "5.0.5-1.el7.x86_64"
 python::version: "python36"
 python::pip: "present"
 python::dev: "present"

--- a/hieradata/org/lsst/role/comcam-arctl.yaml
+++ b/hieradata/org/lsst/role/comcam-arctl.yaml
@@ -82,3 +82,6 @@ accounts::user_list:
   arc:
     uid: 61000
     gid: 61000
+  atadbot:
+    uid: 61002
+    gid: 61002

--- a/hieradata/org/lsst/role/comcam-arctl.yaml
+++ b/hieradata/org/lsst/role/comcam-arctl.yaml
@@ -5,6 +5,10 @@ classes:
   - "redis"
   - "python"
   - "docker"
+packages:
+  - "git"
+  - "cmake"
+  - "gcc-c++"
 # disabling the kernel version check is needed on el7
 docker::overlay2_override_kernel_check: true
 docker::storage_driver: "overlay2"

--- a/hieradata/org/lsst/role/comcam-arctl.yaml
+++ b/hieradata/org/lsst/role/comcam-arctl.yaml
@@ -24,6 +24,13 @@ rabbitmq::repos_ensure: true
 profile::archive::rabbitmq::vhosts:
   "/test_at":
     ensure: "present"
+  "/test_cc":
+    ensure: "present"
+profile::archive::rabbitmq::user_permissions:
+  "iip@/test_cc":
+    configure_permission: ".*"
+    read_permission:      ".*"
+    write_permission:     ".*"
 redis::bind: "127.0.0.1"
 redis::manage_repo: true
 redis::scl: true

--- a/hieradata/org/lsst/role/comcam-arctl.yaml
+++ b/hieradata/org/lsst/role/comcam-arctl.yaml
@@ -4,6 +4,15 @@ classes:
   - "profile::archive::rabbitmq"
   - "redis"
   - "python"
+  - "docker"
+# disabling the kernel version check is needed on el7
+docker::overlay2_override_kernel_check: true
+docker::storage_driver: "overlay2"
+docker::version: "19.03.4"
+# ipa docker group is 70014
+docker::socket_group: "70014"
+docker::socket_override: true
+# install docker-compose at system level - "docker"
 rabbitmq::admin_enable: true
 rabbitmq::management_enable: true
 rabbitmq::manage_python: false
@@ -16,6 +25,10 @@ python::pip: "present"
 python::dev: "present"
 python::virtualenv: "present"
 python::python_pips:
+  # docker-compose is python3 only
+  "docker-compose":
+    virtualenv: "system"
+    ensure: "1.25.0"
   "redis":
     virtualenv: "system"
     ensure: "3.2.1"

--- a/hieradata/org/lsst/role/comcam-arctl.yaml
+++ b/hieradata/org/lsst/role/comcam-arctl.yaml
@@ -31,6 +31,13 @@ profile::archive::rabbitmq::user_permissions:
     configure_permission: ".*"
     read_permission: ".*"
     write_permission: ".*"
+profile::archive::rabbitmq::exchanges:
+  "message@/test_cc":
+    ensure: "present"
+    type: "direct"
+    durable: true
+    user: "%{lookup('profile::archive::rabbitmq::queue_user')}"  # secret
+    password: "%{lookup('profile::archive::rabbitmq::queue_password')}"  # secret
 profile::archive::rabbitmq::arc_queues:
   - "at_foreman_consume"
   - "at_foreman_ack_publish"

--- a/hieradata/org/lsst/role/comcam-arctl.yaml
+++ b/hieradata/org/lsst/role/comcam-arctl.yaml
@@ -78,3 +78,7 @@ python::python_pips:
   "redis":
     virtualenv: "system"
     ensure: "3.5.1"
+accounts::user_list:
+  arc:
+    uid: 61000
+    gid: 61000

--- a/hieradata/org/lsst/role/comcam-arctl.yaml
+++ b/hieradata/org/lsst/role/comcam-arctl.yaml
@@ -3,9 +3,19 @@ classes:
   - "profile::core::common"
   - "profile::archive::rabbitmq"
   - "redis"
+  - "python"
 rabbitmq::admin_enable: true
 rabbitmq::management_enable: true
+rabbitmq::manage_python: false
 redis::bind: "127.0.0.1"
 redis::manage_repo: true
 redis::scl: true
 redis::globals::scl: "rh-redis5"
+python::version: "python36"
+python::pip: "present"
+python::dev: "present"
+python::virtualenv: "present"
+python::python_pips:
+  "redis":
+    virtualenv: "system"
+    ensure: "3.2.1"

--- a/hieradata/org/lsst/role/comcam-arctl.yaml
+++ b/hieradata/org/lsst/role/comcam-arctl.yaml
@@ -29,8 +29,26 @@ profile::archive::rabbitmq::vhosts:
 profile::archive::rabbitmq::user_permissions:
   "iip@/test_cc":
     configure_permission: ".*"
-    read_permission:      ".*"
-    write_permission:     ".*"
+    read_permission: ".*"
+    write_permission: ".*"
+profile::archive::rabbitmq::arc_queues:
+  - "at_foreman_consume"
+  - "at_foreman_ack_publish"
+  - "archive_ctrl_publish"
+  - "archive_ctrl_consume"
+  - "dmcs_consume"
+  - "dmcs_ack_consume"
+  - "ocs_dmcs_consume"
+  - "dmcs_ocs_publish"
+  - "dmcs_fault_consume"
+  - "gen_dmcs_consume"
+  - "at_forwarder_publish"
+  - "f99_consume"
+  - "f91_consume"
+  - "f92_consume"
+  - "f93_consume"
+  - "ar_foreman_ack_publish"
+  - "telemetry_queue"
 redis::bind: "127.0.0.1"
 redis::manage_repo: true
 redis::scl: true

--- a/hieradata/org/lsst/role/comcam-arctl.yaml
+++ b/hieradata/org/lsst/role/comcam-arctl.yaml
@@ -2,5 +2,10 @@
 classes:
   - "profile::core::common"
   - "profile::archive::rabbitmq"
+  - "redis"
 rabbitmq::admin_enable: true
 rabbitmq::management_enable: true
+redis::bind: "127.0.0.1"
+redis::manage_repo: true
+redis::scl: true
+redis::globals::scl: "rh-redis5"

--- a/hieradata/org/lsst/role/comcam-arctl.yaml
+++ b/hieradata/org/lsst/role/comcam-arctl.yaml
@@ -20,6 +20,9 @@ docker::socket_override: true
 rabbitmq::admin_enable: true
 rabbitmq::management_enable: true
 rabbitmq::manage_python: false
+profile::archive::rabbitmq::vhosts:
+  "/test_at":
+    ensure: "present"
 redis::bind: "127.0.0.1"
 redis::manage_repo: true
 redis::scl: true

--- a/hieradata/org/lsst/role/comcam-arctl.yaml
+++ b/hieradata/org/lsst/role/comcam-arctl.yaml
@@ -85,3 +85,6 @@ accounts::user_list:
   atadbot:
     uid: 61002
     gid: 61002
+sudo::configs:
+  comcam_archive_cmd:
+    content: "%comcam-archive-sudo ALL=(arc,atadbot) NOPASSWD: ALL"

--- a/hieradata/org/lsst/role/comcam-arctl.yaml
+++ b/hieradata/org/lsst/role/comcam-arctl.yaml
@@ -20,6 +20,7 @@ docker::socket_override: true
 rabbitmq::admin_enable: true
 rabbitmq::management_enable: true
 rabbitmq::manage_python: false
+rabbitmq::repos_ensure: true
 profile::archive::rabbitmq::vhosts:
   "/test_at":
     ensure: "present"

--- a/hieradata/org/lsst/role/comcam-arctl.yaml
+++ b/hieradata/org/lsst/role/comcam-arctl.yaml
@@ -9,6 +9,12 @@ packages:
   - "git"
   - "cmake"
   - "gcc-c++"
+files:
+  "/etc/profile.d/rh-redis5.sh":
+    mode: "0644"
+    owner: "root"
+    group: "root"
+    content: ". /opt/rh/rh-redis5/enable"
 # disabling the kernel version check is needed on el7
 docker::overlay2_override_kernel_check: true
 docker::storage_driver: "overlay2"

--- a/hieradata/org/lsst/role/comcam-arctl.yaml
+++ b/hieradata/org/lsst/role/comcam-arctl.yaml
@@ -27,6 +27,7 @@ rabbitmq::admin_enable: true
 rabbitmq::management_enable: true
 rabbitmq::manage_python: false
 rabbitmq::repos_ensure: true
+rabbitmq::package_ensure: "3.8.3-1.el7.noarch"
 profile::archive::rabbitmq::vhosts:
   "/test_at":
     ensure: "present"

--- a/hieradata/org/lsst/role/comcam-arctl.yaml
+++ b/hieradata/org/lsst/role/comcam-arctl.yaml
@@ -1,0 +1,6 @@
+---
+classes:
+  - "profile::core::common"
+  - "rabbitmq"
+rabbitmq::admin_enable: true
+rabbitmq::management_enable: true

--- a/hieradata/site/ls/role/comcam-arctl.yaml
+++ b/hieradata/site/ls/role/comcam-arctl.yaml
@@ -1,0 +1,21 @@
+---
+classes:
+  - "profile::core::nfsserver"
+  - "profile::core::nfsclient"
+
+nfs::server_enabled: true
+nfs::nfs_v4_export_root_clients: >-
+  %{facts.networking.ip}/32(ro,fsid=root,insecure,no_subtree_check,async,root_squash)
+  139.229.146.0/24(ro,fsid=root,insecure,no_subtree_check,async,root_squash)
+nfs::nfs_exports_global:
+  /data/lsstdata:
+    clients: >-
+      %{facts.networking.ip}/32(ro,nohide,insecure,no_subtree_check,async,root_squash)
+      139.229.146.0/24(ro,nohide,insecure,no_subtree_check,async,root_squash)
+
+nfs::client_enabled: true
+nfs::client_mounts:
+  /net/data/lsstdata:
+    share: "lsstdata"
+    server: "%{facts.fqdn}"
+    atboot: true

--- a/site/profile/manifests/archive/rabbitmq.pp
+++ b/site/profile/manifests/archive/rabbitmq.pp
@@ -1,6 +1,7 @@
 class profile::archive::rabbitmq(
-  Hash[String, Hash] $users = {},
-  Hash[String, Hash] $vhosts = {},
+  Hash[String, Hash] $users     = {},
+  Hash[String, Hash] $vhosts    = {},
+  Hash[String, Hash] $exchanges = {},
 ){
   include ::rabbitmq
 
@@ -10,5 +11,8 @@ class profile::archive::rabbitmq(
   }
   unless (empty($vhosts)) {
     ensure_resources('rabbitmq_vhost', $vhosts)
+  }
+  unless (empty($exchanges)) {
+    ensure_resources('rabbitmq_exchange', $exchanges)
   }
 }

--- a/site/profile/manifests/archive/rabbitmq.pp
+++ b/site/profile/manifests/archive/rabbitmq.pp
@@ -3,6 +3,7 @@ class profile::archive::rabbitmq(
   Hash[String, Hash] $vhosts    = {},
   Hash[String, Hash] $exchanges = {},
   Hash[String, Hash] $queues    = {},
+  Hash[String, Hash] $bindings  = {},
 ){
   include ::rabbitmq
 
@@ -18,5 +19,8 @@ class profile::archive::rabbitmq(
   }
   unless (empty($queues)) {
     ensure_resources('rabbitmq_queue', $queues)
+  }
+  unless (empty($bindings)) {
+    ensure_resources('rabbitmq_binding', $bindings)
   }
 }

--- a/site/profile/manifests/archive/rabbitmq.pp
+++ b/site/profile/manifests/archive/rabbitmq.pp
@@ -1,0 +1,10 @@
+class profile::archive::rabbitmq(
+  Hash[String, Hash] $users = {},
+){
+  include ::rabbitmq
+
+  # XXX hiera support should be upstreamed
+  unless (empty($users)) {
+    ensure_resources('rabbitmq_user', $users)
+  }
+}

--- a/site/profile/manifests/archive/rabbitmq.pp
+++ b/site/profile/manifests/archive/rabbitmq.pp
@@ -1,10 +1,14 @@
 class profile::archive::rabbitmq(
   Hash[String, Hash] $users = {},
+  Hash[String, Hash] $vhosts = {},
 ){
   include ::rabbitmq
 
   # XXX hiera support should be upstreamed
   unless (empty($users)) {
     ensure_resources('rabbitmq_user', $users)
+  }
+  unless (empty($vhosts)) {
+    ensure_resources('rabbitmq_vhost', $vhosts)
   }
 }

--- a/site/profile/manifests/archive/rabbitmq.pp
+++ b/site/profile/manifests/archive/rabbitmq.pp
@@ -5,6 +5,9 @@ class profile::archive::rabbitmq(
   Hash[String, Hash] $queues           = {},
   Hash[String, Hash] $bindings         = {},
   Hash[String, Hash] $user_permissions = {},
+  Array              $arc_queues       = [],
+  Optional[String]   $queue_user       = undef,
+  Optional[String]   $queue_password   = undef,
 ){
   include ::rabbitmq
 
@@ -32,5 +35,23 @@ class profile::archive::rabbitmq(
   }
   unless (empty($user_permissions)) {
     ensure_resources('rabbitmq_user_permissions', $user_permissions)
+  }
+
+  unless (empty($arc_queues)) {
+    $arc_queues.each |String $q| {
+      rabbitmq_queue { "${q}@/test_cc":
+        ensure   => present,
+        user     => $queue_user,
+        password => $queue_password,
+        durable  => true,
+      }
+      rabbitmq_binding { "message@${q}@/test_cc":
+        ensure           => present,
+        user             => $queue_user,
+        password         => $queue_password,
+        destination_type => 'queue',
+        routing_key      => $q,
+      }
+    }
   }
 }

--- a/site/profile/manifests/archive/rabbitmq.pp
+++ b/site/profile/manifests/archive/rabbitmq.pp
@@ -8,6 +8,12 @@ class profile::archive::rabbitmq(
 ){
   include ::rabbitmq
 
+  yum::install { 'erlang':
+    ensure => present,
+    source => 'https://github.com/rabbitmq/erlang-rpm/releases/download/v22.3.4/erlang-22.3.4-1.el7.x86_64.rpm',
+    notify => Class['rabbitmq'],
+  }
+
   # XXX hiera support should be upstreamed
   unless (empty($users)) {
     ensure_resources('rabbitmq_user', $users)

--- a/site/profile/manifests/archive/rabbitmq.pp
+++ b/site/profile/manifests/archive/rabbitmq.pp
@@ -1,9 +1,10 @@
 class profile::archive::rabbitmq(
-  Hash[String, Hash] $users     = {},
-  Hash[String, Hash] $vhosts    = {},
-  Hash[String, Hash] $exchanges = {},
-  Hash[String, Hash] $queues    = {},
-  Hash[String, Hash] $bindings  = {},
+  Hash[String, Hash] $users            = {},
+  Hash[String, Hash] $vhosts           = {},
+  Hash[String, Hash] $exchanges        = {},
+  Hash[String, Hash] $queues           = {},
+  Hash[String, Hash] $bindings         = {},
+  Hash[String, Hash] $user_permissions = {},
 ){
   include ::rabbitmq
 
@@ -22,5 +23,8 @@ class profile::archive::rabbitmq(
   }
   unless (empty($bindings)) {
     ensure_resources('rabbitmq_binding', $bindings)
+  }
+  unless (empty($user_permissions)) {
+    ensure_resources('rabbitmq_user_permissions', $user_permissions)
   }
 }

--- a/site/profile/manifests/archive/rabbitmq.pp
+++ b/site/profile/manifests/archive/rabbitmq.pp
@@ -2,6 +2,7 @@ class profile::archive::rabbitmq(
   Hash[String, Hash] $users     = {},
   Hash[String, Hash] $vhosts    = {},
   Hash[String, Hash] $exchanges = {},
+  Hash[String, Hash] $queues    = {},
 ){
   include ::rabbitmq
 
@@ -14,5 +15,8 @@ class profile::archive::rabbitmq(
   }
   unless (empty($exchanges)) {
     ensure_resources('rabbitmq_exchange', $exchanges)
+  }
+  unless (empty($queues)) {
+    ensure_resources('rabbitmq_queue', $queues)
   }
 }


### PR DESCRIPTION
The initial comcam-arctl role:
* installs rabbitmq 3.8.3 + manage queue creation
* installs redis 5.0.5 from scl + enables the scl by default
* installs redis package from pypi
* installs docker + docker-compose
* nfs exports `/data/lsstdata`
* manages the `arc` user + `archive` group
* manages the `atadbot` user/group
* installs a sudo rule to allow members of the `comcam-archive-sudo` user group to `sudo` to role accounts without a passphrase