### PR TITLE
Add profile::headerservice_conda

### DIFF
--- a/hieradata/org/ncsa/role/headerservice.yaml
+++ b/hieradata/org/ncsa/role/headerservice.yaml
@@ -7,8 +7,11 @@ classes:
   - profile::ncsa::system_authnz
   - profile::ncsa::xcat_client
   - profile::sal
-    #  - profile::sal_firewall
+  - profile::headerservice_conda
 
 sal2::ospl_version: "6.9.0"
 sal2::ts_idl_version: "1.2.0_5.1.0"
 sal2::ts_salobj_version: "5.14.0"
+
+profile::headerservice_conda::fitsio_version: "1.0.4"
+profile::headerservice_conda::headerservice_version: "2.2.0"

--- a/hieradata/site/nts.yaml
+++ b/hieradata/site/nts.yaml
@@ -9,6 +9,9 @@ profile::ncsa::puppet_master::firewall_allow_from:
   - "172.30.18.0/23"
   - "172.30.20.0/25"
 
+profile::headerservice_conda::allowed_subnets:
+  - "141.142.238.0/23"
+
 rsyslog::client::actions:
   ncsa_security_loghost:
     type: "omrelp"
@@ -91,6 +94,15 @@ rsyslog::client::global_config:
     value: "64k"
   preserveFQDN:
     value: "on"
+
+sal2::firewall::multicast_cidr: "239.255.0.1/32"
+sal2::firewall::omgdds_subnets:
+  - "141.142.237.0/24"
+  - "141.142.238.0/23"
+sal2::firewall::opensplice_subnets:
+  - "141.142.237.0/24"
+  - "141.142.238.0/23"
+
 
 xcat::network_mgmt: "172.30.18.0/23"
 xcat::network_ipmi: "192.168.28.0/23"

--- a/site/profile/manifests/headerservice_conda.pp
+++ b/site/profile/manifests/headerservice_conda.pp
@@ -1,0 +1,40 @@
+# @summary Install headerservice and dependencies from miniconda
+#
+# Install headerservice and dependencies from miniconda.
+# Also setup firewall exceptions.
+#
+# @param allowed_subnets
+#        Web access allowed from these networks
+#
+# @param fitsio_version
+#        Version string for fitsio conda package
+#
+# @param version
+#        Version string for headerservice conda package
+#
+class profile::headerservice_conda (
+  Array  $allowed_subnets,
+  String $fitsio_version,
+  String $headerservice_version,
+) {
+
+  # CONDA PACKAGES
+  $conda_pkgs = [
+    'ipython',
+    'pyyaml',
+    "fitsio==${fitsio_version}",
+    "headerservice=${headerservice_version}",
+  ]
+  miniconda::package { $conda_pkgs : }
+
+  # FIREWALL
+  $allowed_subnets.each | $source |
+  {
+    firewall { "510 ${module_name}::headerservice_conda allow access to HeaderService from ${source}" :
+      dport  => [8000,9000],
+      source => $source,
+      action => 'accept',
+    }
+  }
+
+}

--- a/site/profile/manifests/sal.pp
+++ b/site/profile/manifests/sal.pp
@@ -4,6 +4,7 @@ class profile::sal (
 ) {
 
   include ::sal2
+  include ::sal2::firewall
   include ::miniconda
   include ::python
 


### PR DESCRIPTION
Creates profile::headerservice_conda
for deploying headerservice directly from conda
still needed for testing new version before pushing to production