### PR TITLE
Add profile::ncsa::lhn_target_from_bdc

### DIFF
--- a/hieradata/org/ncsa.yaml
+++ b/hieradata/org/ncsa.yaml
@@ -78,28 +78,6 @@ pakrat_client::repos:
     # if we use GPG key checking, it's probably because we have only CentOS-built RPMs in the repo
     gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7"
 
-profile::ncsa::allow_qualys_scan::ip: "141.142.148.51"
-
-profile::ncsa::allow_ssh_from_bastion::bastion_nodelist:
-  - 10.142.181.15
-  - 141.142.181.15
-profile::ncsa::allow_ssh_from_bastion::allow_groups:
-  - lsst_admin_ncsa
-  - lsst_int_bastion
-
-profile::ncsa::allow_ssh_from_login::login_nodelist:
-  - 10.142.181.16
-  - 10.142.181.17
-  - 10.142.181.18
-  - 141.142.181.16
-  - 141.142.181.17
-  - 141.142.181.18
-profile::ncsa::allow_ssh_from_login::allow_groups:
-  - lsst_admin_ncsa
-
-profile::ncsa::allow_sudo::groups:
-  - lsst_admin_ncsa
-
 python::dev: "present"
 python::pip: "present"
 python::python_pips:

--- a/hieradata/org/ncsa/role/lhntest.yaml
+++ b/hieradata/org/ncsa/role/lhntest.yaml
@@ -1,0 +1,17 @@
+---
+classes:
+  - profile::ncsa::allow_qualys_scan
+  - profile::ncsa::allow_ssh_from_bastion
+  - profile::ncsa::allow_ssh_from_login
+  - profile::ncsa::baseline_cfg
+  - profile::ncsa::lhn_target_from_bdc
+  - profile::ncsa::system_authnz
+  - profile::ncsa::xcat_client
+  - profile::sal
+
+profile::ncsa::allow_sudo::groups:
+  - "lsst_admin_tucson"
+
+sal2::ospl_version: "6.9.0"
+sal2::ts_idl_version: "1.2.2_4.1.1_6.0.0"
+sal2::ts_salobj_version: "5.15.0"

--- a/hieradata/site/nts/role/puppet_master.yaml
+++ b/hieradata/site/nts/role/puppet_master.yaml
@@ -1,0 +1,7 @@
+---
+profile::ncsa::allow_ssh_from_bastion:
+  - "lsst_level1_adm"
+profile::ncsa::allow_ssh_from_login:
+  - "lsst_level1_adm"
+profile::ncsa::allow_sudo::groups:
+  - "lsst_level1_adm"

--- a/site/profile/data/common.yaml
+++ b/site/profile/data/common.yaml
@@ -1,21 +1,9 @@
 ---
 # Override default hiera lookup options (keep this at the top)
 lookup_options:
-  profile::ncsa::allow_ssh_from_login::allow_groups:
-    merge: "unique"
-  profile::ncsa::allow_ssh_from_bastion::allow_groups:
-    merge: "unique"
-  profile::ncsa::allow_sudo::groups:
-    merge: "unique"
-  profile::ncsa::allow_sudo::users:
-    merge: "unique"
   profile::sal::miniconda_pkgs:
     merge: "unique"
 
 # Everything else goes down below. Sort keys alphabetically
-
-profile::ncsa::allow_ssh_from_bastion::custom_cfg: {}
-
-profile::ncsa::allow_ssh_from_login::custom_cfg: {}
 
 profile::sal::miniconda_pkgs: []

--- a/site/profile/data/org/ncsa.yaml
+++ b/site/profile/data/org/ncsa.yaml
@@ -1,0 +1,49 @@
+---
+# Override default hiera lookup options (keep this at the top)
+lookup_options:
+  profile::ncsa::allow_ssh_from_bastion::allow_groups:
+    merge: "unique"
+  profile::ncsa::allow_ssh_from_bdc::allow_groups:
+    merge: "unique"
+  profile::ncsa::allow_ssh_from_login::allow_groups:
+    merge: "unique"
+  profile::ncsa::allow_sudo::groups:
+    merge: "unique"
+  profile::ncsa::allow_sudo::users:
+    merge: "unique"
+
+# Everything else goes down below. Sort keys alphabetically
+
+profile::ncsa::allow_ssh_from_bastion::allow_groups:
+  - "lsst_admin_ncsa"
+  - "lsst_int_bastion"
+profile::ncsa::allow_ssh_from_bastion::bastion_nodelist:
+  - "10.142.181.15"
+  - "141.142.181.15"
+profile::ncsa::allow_ssh_from_bastion::custom_cfg: {}
+
+profile::ncsa::allow_ssh_from_bdc::allow_groups:
+  - "lsst_admin_ncsa"
+  - "lsst_admin_tucson"
+profile::ncsa::allow_ssh_from_bdc::custom_cfg: {}
+profile::ncsa::allow_ssh_from_bdc::nodelist:
+  - "139.229.140.0/22"
+  - "139.229.146.0/24"
+  - "139.229.149.0/24"
+
+
+profile::ncsa::allow_ssh_from_login::allow_groups:
+  - "lsst_admin_ncsa"
+profile::ncsa::allow_ssh_from_login::custom_cfg: {}
+profile::ncsa::allow_ssh_from_login::login_nodelist:
+  - "10.142.181.16"
+  - "10.142.181.17"
+  - "10.142.181.18"
+  - "141.142.181.16"
+  - "141.142.181.17"
+  - "141.142.181.18"
+
+profile::ncsa::allow_sudo::groups:
+  - "lsst_admin_ncsa"
+
+profile::ncsa::allow_qualys_scan::ip: "141.142.148.51"

--- a/site/profile/manifests/ncsa/allow_ssh_from_bdc.pp
+++ b/site/profile/manifests/ncsa/allow_ssh_from_bdc.pp
@@ -1,0 +1,45 @@
+# @summary Allow incoming ssh from BDC nodes
+#
+# Allow incoming ssh from BDC nodes
+#
+# @param
+#   nodelist
+#   Type: Array
+#   Desc: one or more hostnames / IPs / CIDRs
+#         Note: must contain at least 1 item
+# @param
+#   allow_groups
+#   Type: Array
+#   Desc: one or more LDAP / UNIX groups that are allowed to login from
+#         any of the nodes in nodelist
+#         Note: can be empty
+# @example
+#   include profile::allow_ssh_from_BDC
+#
+class profile::ncsa::allow_ssh_from_bdc (
+  Array[ String ]    $allow_groups,
+  Array[ String, 1 ] $nodelist,
+  Hash               $custom_cfg,
+) {
+  $parms_local = {
+    'PubkeyAuthentication'   => 'yes',
+    'KerberosAuthentication' => 'yes',
+    'GSSAPIAuthentication'   => 'yes',
+  }
+
+  #add in allow_groups if non-empty
+  if size( $allow_groups ) > 0 {
+    $groups = { 'AllowGroups' => $allow_groups }
+  }
+  else {
+    $groups = {}
+  }
+
+  $params = $parms_local + $groups + $custom_cfg
+
+  ::sshd::allow_from{ 'allow ssh from BDC nodes':
+    hostlist                => $nodelist,
+    groups                  => $allow_groups,
+    additional_match_params => $params,
+  }
+}

--- a/site/profile/manifests/ncsa/lhn_target_from_bdc.pp
+++ b/site/profile/manifests/ncsa/lhn_target_from_bdc.pp
@@ -1,0 +1,17 @@
+class profile::ncsa::lhn_target_from_bdc {
+
+  $protocols = [ 'udp', 'tcp' ]
+  $sources = [ '139.229.140.0/22', '139.229.146.0/24', '139.229.149.0/24' ]
+
+  $protocols.each | $proto | {
+    $sources.each | $src | {
+      firewall { "550 profile::ncsa::allow_lhn_from_bdc - ${src} + ${proto}" :
+        action => 'accept',
+        dport  => '5000-5050',
+        source => $src,
+        proto  => $proto,
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
Creates a role and cluster for Long Haul Network (LHN) testing to nodes in the NCSA Test Stand.

- Add cluster lhntest
- Add level1_adm access to puppetmaster nodes in NTS
- Add profile::ncsa::allow_ssh_from_bdc (not actually used)
- Add role ncsa::lhntest
- Hieradata moved to ncsa::role::lhntest
- Move hieradata for profile::ncsa into org/ncsa