### PR TITLE
IT-2427: icinga master as CA for icinga agents

### DIFF
--- a/site/profile/manifests/core/icinga_agent.pp
+++ b/site/profile/manifests/core/icinga_agent.pp
@@ -6,6 +6,7 @@ class profile::core::icinga_agent(
   String $icinga_master_ip,
   String $credentials_hash,
   String $host_template,
+  String $ca_salt,
 ){
   $packages = [
     'nagios-plugins-all',
@@ -63,10 +64,11 @@ class profile::core::icinga_agent(
   }
   ##Icinga2 feature API config
   class { '::icinga2::feature::api':
-    pki             => 'puppet',
+    ensure          => 'present',
+    ca_host         => $icinga_master_ip,
+    ticket_salt     => $ca_salt,
     accept_config   => true,
     accept_commands => true,
-    ensure          => 'present',
     endpoints       => {
       $icinga_agent_fqdn  => {
         'host'  =>  $icinga_agent_ip

--- a/site/profile/manifests/core/icinga_master.pp
+++ b/site/profile/manifests/core/icinga_master.pp
@@ -21,6 +21,7 @@ class profile::core::icinga_master (
   String $api_user,
   String $api_pwd,
   String $credentials_hash,
+  String $ca_salt,
 ){
   include profile::core::letsencrypt
   include remi
@@ -153,6 +154,7 @@ class profile::core::icinga_master (
     confd       => false,
     constants   => {
       'ZoneName'   => 'master',
+      'TicketSalt' => $ca_salt,
     },
     features    => ['checker','mainlog','statusdata','compatlog','command'],
   }
@@ -165,9 +167,10 @@ class profile::core::icinga_master (
     require       => Mysql::Db[$mysql_icingaweb_db],
   }
   class { '::icinga2::feature::api':
-    pki             => 'puppet',
+    pki             => 'none',
     accept_config   => true,
     accept_commands => true,
+    ca_host         => $master_ip,
     ensure          => 'present',
     endpoints       => {
       $master_fqdn    => {
@@ -180,6 +183,8 @@ class profile::core::icinga_master (
       },
     },
   }
+  include ::icinga2::pki::ca
+
   class { '::icinga2::feature::notification':
     ensure    => present,
     enable_ha => true,


### PR DESCRIPTION
Now we can add an agent that doesn't belong to puppet (like switches or vmware clusters)