### PR TITLE
forward 136.229.139.in-addr.arpa to crux (active directory)

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -20,7 +20,7 @@ mod 'bodgit/scl', '1.0.1'
 mod 'theforeman/dhcp',
   git: 'https://github.com/lsst-it/puppet-dhcp',
   ref: 'c9304257d4a800008baa3406e453fc9393faf7b7'
-mod 'theforeman/dns', '6.2.0'
+mod 'theforeman/dns', '8.0.0'
 mod 'duritong/sysctl',
   git: 'https://github.com/lsst-it/puppet-sysctl',
   ref: 'working'

--- a/hieradata/site/ls/role/dnscache.yaml
+++ b/hieradata/site/ls/role/dnscache.yaml
@@ -13,7 +13,13 @@ dns::zones:
     zonetype: "forward"
     forward: "only"
     forwarders:
-      - "139.229.136.23"
+      - &crux "139.229.136.23"
+  "136.229.139.in-addr.arpa":
+    reverse: true
+    zonetype: "forward"
+    forward: "only"
+    forwarders:
+      - *crux
 dns::additional_directives:
   - "logging {"
   - "    channel queries_syslog {"


### PR DESCRIPTION
```
[root@dns2 ~]# dig +short -x 139.229.136.32
spectator.lsst.local.
```