### PR TITLE
IT-2373: velero client and autocompletion

### DIFF
--- a/hieradata/cluster/ruka.yaml
+++ b/hieradata/cluster/ruka.yaml
@@ -1,6 +1,7 @@
 ---
 classes:
   - "profile::core::ifdown"
+  - "profile::core::velero"
 packages:
   - "perccli"  # from dell repo
 profile::core::ifdown::interface: "em1"

--- a/hieradata/cluster/vk8s.yaml
+++ b/hieradata/cluster/vk8s.yaml
@@ -1,0 +1,5 @@
+---
+classes:
+  - "profile::core::velero"
+
+profile::core::kernel::version: "3.10.0-1127.8.2.el7.x86_64"

--- a/site/profile/manifests/core/velero.pp
+++ b/site/profile/manifests/core/velero.pp
@@ -1,32 +1,20 @@
 # @summary
 #   Velero cli instalation and autocompletion
 
-class profile::core::velero
-{
-  $runif1  = 'test ! -f /usr/bin/velero'
-  $runif2  = 'test ! -f /etc/bash_completion.d/velero'
-  $runif3  = 'test ! -d /var/tmp/velero-v1.4.0-linux-amd64'
+class profile::core::velero {
+  $runif  = 'test ! -f /etc/bash_completion.d/velero'
+  $command = 'velero completion bash > /etc/bash_completion.d/velero'
 
-  $command1 = 'wget -qO- https://github.com/vmware-tanzu/velero/releases/download/v1.4.0/velero-v1.4.0-linux-amd64.tar.gz | tar xz; mv velero-v1.4.0-linux-amd64/velero /usr/bin/velero'
-  $command2 = 'velero completion bash > /etc/bash_completion.d/velero'
-  $command3 = 'rm -rf /var/tmp/velero-v1.4.0-linux-amd64'
-
-  exec { $command1:
-    cwd      => '/var/tmp',
-    path     => ['/sbin', '/usr/sbin', '/bin'],
-    provider => shell,
-    onlyif   => $runif1,
+  vcsrepo { '/usr/share/velero':
+    ensure   => present,
+    provider => git,
+    source   => 'git://github.com/vmware-tanzu/velero.git',
+    revision => 'v1.4.2',
   }
-  -> exec { $command2:
+  exec { $command:
     cwd      => '/var/tmp',
     path     => ['/sbin', '/usr/sbin', '/bin'],
     provider => shell,
-    onlyif   => $runif2,
-  }
-  -> exec { $command3:
-    cwd      => '/var/tmp',
-    path     => ['/sbin', '/usr/sbin', '/bin'],
-    provider => shell,
-    onlyif   => $runif3,
+    onlyif   => $runif,
   }
 }

--- a/site/profile/manifests/core/velero.pp
+++ b/site/profile/manifests/core/velero.pp
@@ -1,0 +1,32 @@
+# @summary
+#   Velero cli instalation and autocompletion
+
+class profile::core::velero
+{
+  $runif1  = 'test ! -f /usr/bin/velero'
+  $runif2  = 'test ! -f /etc/bash_completion.d/velero'
+  $runif3  = 'test ! -d /var/tmp/velero-v1.4.0-linux-amd64'
+
+  $command1 = 'wget -qO- https://github.com/vmware-tanzu/velero/releases/download/v1.4.0/velero-v1.4.0-linux-amd64.tar.gz | tar xz; mv velero-v1.4.0-linux-amd64/velero /usr/bin/velero'
+  $command2 = 'velero completion bash > /etc/bash_completion.d/velero'
+  $command3 = 'rm -rf /var/tmp/velero-v1.4.0-linux-amd64'
+
+  exec { $command1:
+    cwd      => '/var/tmp',
+    path     => ['/sbin', '/usr/sbin', '/bin'],
+    provider => shell,
+    onlyif   => $runif1,
+  }
+  -> exec { $command2:
+    cwd      => '/var/tmp',
+    path     => ['/sbin', '/usr/sbin', '/bin'],
+    provider => shell,
+    onlyif   => $runif2,
+  }
+  -> exec { $command3:
+    cwd      => '/var/tmp',
+    path     => ['/sbin', '/usr/sbin', '/bin'],
+    provider => shell,
+    onlyif   => $runif3,
+  }
+}


### PR DESCRIPTION
The exec is due to no existence of a module that incorporates velero autocompletion (as well as happened with kubectl) 