### PR TITLE
IT-2487: change network 1621 for 1101

### DIFF
--- a/hieradata/site/cp/role/atarchiver.yaml
+++ b/hieradata/site/cp/role/atarchiver.yaml
@@ -7,33 +7,33 @@ classes:
 # Server configuration
 nfs::server_enabled: true
 nfs::nfs_v4_export_root_clients: >-
-  139.229.162.0/25(ro,fsid=root,insecure,no_subtree_check,async,root_squash)
+  139.229.160.0/24(ro,fsid=root,insecure,no_subtree_check,async,root_squash)
   139.229.167.0/24(ro,fsid=root,insecure,no_subtree_check,async,root_squash)
   139.229.170.0/24(ro,fsid=root,insecure,no_subtree_check,async,root_squash)
 nfs::nfs_exports_global:
   /data/export:
     clients: >-
-      139.229.162.0/25(ro,nohide,insecure,no_subtree_check,async,root_squash)
+      139.229.160.0/24(ro,nohide,insecure,no_subtree_check,async,root_squash)
       139.229.167.0/24(ro,nohide,insecure,no_subtree_check,async,root_squash)
       139.229.170.0/24(ro,nohide,insecure,no_subtree_check,async,root_squash)
   /data/butler:
     clients: >-
-      139.229.162.0/25(ro,nohide,insecure,no_subtree_check,async,root_squash)
+      139.229.160.0/24(ro,nohide,insecure,no_subtree_check,async,root_squash)
       139.229.167.0/24(ro,nohide,insecure,no_subtree_check,async,root_squash)
       139.229.170.0/24(ro,nohide,insecure,no_subtree_check,async,root_squash)
   /data/staging/atforwarder:
     clients: >-
-      139.229.162.0/25(ro,nohide,insecure,no_subtree_check,async,root_squash)
+      139.229.160.0/24(ro,nohide,insecure,no_subtree_check,async,root_squash)
       139.229.167.0/24(ro,nohide,insecure,no_subtree_check,async,root_squash)
       139.229.170.0/24(ro,nohide,insecure,no_subtree_check,async,root_squash)
   /data/staging/dbb:
     clients: >-
-      139.229.162.0/25(ro,nohide,insecure,no_subtree_check,async,root_squash)
+      139.229.160.0/24(ro,nohide,insecure,no_subtree_check,async,root_squash)
       139.229.167.0/24(ro,nohide,insecure,no_subtree_check,async,root_squash)
       139.229.170.0/24(ro,nohide,insecure,no_subtree_check,async,root_squash)
   /data/staging/oods:
     clients: >-
-      139.229.162.0/25(ro,nohide,insecure,no_subtree_check,async,root_squash)
+      139.229.160.0/24(ro,nohide,insecure,no_subtree_check,async,root_squash)
       139.229.167.0/24(ro,nohide,insecure,no_subtree_check,async,root_squash)
       139.229.170.0/24(ro,nohide,insecure,no_subtree_check,async,root_squash)
 

--- a/hieradata/site/cp/role/atsdaq.yaml
+++ b/hieradata/site/cp/role/atsdaq.yaml
@@ -7,7 +7,7 @@ classes:
 nfs::server_enabled: true
 nfs::nfs_v4_export_root_clients: >-
   192.168.100.0/24(rw,fsid=root,insecure,no_subtree_check,async,root_squash)
-  139.229.162.0/25(ro,fsid=root,insecure,no_subtree_check,async,root_squash)
+  139.229.160.0/24(ro,fsid=root,insecure,no_subtree_check,async,root_squash)
   139.229.167.0/24(ro,fsid=root,insecure,no_subtree_check,async,root_squash)
   139.229.170.0/24(rw,fsid=root,insecure,no_subtree_check,async,root_squash)
   139.229.175.0/25(rw,fsid=root,insecure,no_subtree_check,async,root_squash)
@@ -20,7 +20,7 @@ nfs::nfs_exports_global:
       192.168.100.0/24(rw,nohide,insecure,no_subtree_check,async,all_squash,anongid=2660)
   /data:
     clients: >-
-      139.229.162.0/25(ro,nohide,insecure,no_subtree_check,async,root_squash)
+      139.229.160.0/24(ro,nohide,insecure,no_subtree_check,async,root_squash)
       139.229.167.0/24(ro,nohide,insecure,no_subtree_check,async,root_squash)
       139.229.170.0/24(rw,nohide,insecure,no_subtree_check,async,root_squash)
       139.229.175.0/25(rw,nohide,insecure,no_subtree_check,async,root_squash)

--- a/hieradata/site/cp/role/nfsserver.yaml
+++ b/hieradata/site/cp/role/nfsserver.yaml
@@ -7,38 +7,38 @@ classes:
 # Server configuration
 nfs::server_enabled: true
 
-# andes source IPs may be in either 139.229.162.0/25 or 139.229.170.0/24
+# andes source IPs may be in either 139.229.160.0/24 or 139.229.170.0/24
 nfs::nfs_v4_export_root_clients: >-
-  139.229.162.0/25(rw,fsid=root,insecure,no_subtree_check,async,root_squash)
+  139.229.160.0/24(rw,fsid=root,insecure,no_subtree_check,async,root_squash)
   139.229.167.0/24(rw,fsid=root,insecure,no_subtree_check,async,root_squash)
   139.229.170.0/24(rw,fsid=root,insecure,no_subtree_check,async,root_squash)
 nfs::nfs_exports_global:
   /data/home:
     clients: >-
-      139.229.162.0/25(rw,nohide,insecure,no_subtree_check,async,root_squash)
+      139.229.160.0/24(rw,nohide,insecure,no_subtree_check,async,root_squash)
       139.229.167.0/24(rw,nohide,insecure,no_subtree_check,async,root_squash)
       139.229.170.0/24(rw,nohide,insecure,no_subtree_check,async,root_squash)
   /data/jhome:
     # nublado needs to be able to create user home dirs as root
     clients: >-
-      139.229.162.0/25(rw,nohide,insecure,no_subtree_check,async,no_root_squash)
+      139.229.160.0/24(rw,nohide,insecure,no_subtree_check,async,no_root_squash)
       139.229.167.0/24(rw,nohide,insecure,no_subtree_check,async,no_root_squash)
       139.229.170.0/24(rw,nohide,insecure,no_subtree_check,async,no_root_squash)
   /data/lsstdata:
     clients: >-
-      139.229.162.0/25(ro,nohide,insecure,no_subtree_check,async,root_squash)
+      139.229.160.0/24(ro,nohide,insecure,no_subtree_check,async,root_squash)
       139.229.167.0/24(ro,nohide,insecure,no_subtree_check,async,root_squash)
       139.229.170.0/24(ro,nohide,insecure,no_subtree_check,async,root_squash)
       atarchiver.cp.lsst.org(rw,nohide,insecure,no_subtree_check,async,root_squash)
       139.229.170.21(rw,nohide,insecure,no_subtree_check,async,root_squash)
   /data/project:
     clients: >-
-      139.229.162.0/25(rw,nohide,insecure,no_subtree_check,async,root_squash)
+      139.229.160.0/24(rw,nohide,insecure,no_subtree_check,async,root_squash)
       139.229.167.0/24(rw,nohide,insecure,no_subtree_check,async,root_squash)
       139.229.170.0/24(rw,nohide,insecure,no_subtree_check,async,root_squash)
   /data/scratch:
     clients: >-
-      139.229.162.0/25(rw,nohide,insecure,no_subtree_check,async,root_squash)
+      139.229.160.0/24(rw,nohide,insecure,no_subtree_check,async,root_squash)
       139.229.167.0/24(rw,nohide,insecure,no_subtree_check,async,root_squash)
       139.229.170.0/24(rw,nohide,insecure,no_subtree_check,async,root_squash)
 


### PR DESCRIPTION
NFS permitted exports were pointing to the old IT Network, so the NFS mount couldn't proceed.