### PR TITLE
IT-2498: update syslog destination

### DIFF
--- a/hieradata/site/cp.yaml
+++ b/hieradata/site/cp.yaml
@@ -2,20 +2,20 @@
 easy_ipa::ipa_master_fqdn: "ipa01.cp.lsst.org"
 
 rsyslog::config::actions:
-#Send copy to logs to Base Graylog instance
-  graylogBase:
+  #Send copy to logs to GKE Graylog instance
+  graylogCloud:
     type: "omfwd"
-    facility: "*.*;auth,authpriv.none"
+    facility: "*.*"
     config:
-      Target: "it-graylog.ls.lsst.org"
+      Target: "collector.lsst.cloud"
       Port: 5514
       Protocol: "udp"
-  #Send copy to logs to Summit's Graylog instance
-  graylogSummit:
+  #Send copy to logs to Base Graylog instance
+  graylogBase:
     type: "omfwd"
-    facility: "*.*;auth,authpriv.none"
+    facility: "*.*"
     config:
-      Target: "graylog.lsst.cloud"
+      Target: "collector.ls.lsst.org"
       Port: 5514
       Protocol: "udp"
   # Log anything (except mail) of level info or higher.


### PR DESCRIPTION
Syslog was pointing to an obsolete destination on cp site, so no syslog are being fetch in neither graylog interfaces.