### PR TITLE
add daq-mgmt role

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -17,9 +17,7 @@ mod 'puppet/r10k', '8.0.0'
 mod 'puppetlabs/ruby', '1.0.1'
 mod 'camptocamp/systemd', '2.6.0'
 mod 'bodgit/scl', '1.0.1'
-mod 'theforeman/dhcp',
-  git: 'https://github.com/lsst-it/puppet-dhcp',
-  ref: 'c9304257d4a800008baa3406e453fc9393faf7b7'
+mod 'theforeman/dhcp', '6.1.0'
 mod 'theforeman/dns', '8.0.0'
 mod 'duritong/sysctl',
   git: 'https://github.com/lsst-it/puppet-sysctl',

--- a/hieradata/org/lsst/role/daq-mgmt.yaml
+++ b/hieradata/org/lsst/role/daq-mgmt.yaml
@@ -1,19 +1,13 @@
 ---
-#
-# This role is essentially <daq-mgmt role> + <profile::ccs::common profile>.
-# It should go away once comcam has a dedicated daq managment node.
-#
 classes:
   - "profile::core::common"
-  - "profile::ccs::common"
-  - "profile::ccs::daq4"
   - "dhcp"
 
 profile::ccs::facts::daq: true
 # enable ntp server for DAQ
 chrony::port: 123
 chrony::queryhosts:
-  - "192.168.100/24"
+  - "192.168/16"
 chrony::clientlog: true
 
 # dhcp for DAQ + clients

--- a/hieradata/org/lsst/role/daq-mgmt.yaml
+++ b/hieradata/org/lsst/role/daq-mgmt.yaml
@@ -11,6 +11,7 @@ chrony::queryhosts:
 chrony::clientlog: true
 
 # dhcp for DAQ + clients
+dhcp::authoritative: true
 dhcp::interfaces:
   - "lsst-daq"
 dhcp::bootp: true


### PR DESCRIPTION
Create a new role for daq management only nodes.  At present, this is intended for the `atsdaq-mgmt` host but a dedicated daq management node for comcam is planned for the future.