### PR TITLE
IT-2962 update ncsa OS snapshot

### DIFF
--- a/hieradata/org/ncsa.yaml
+++ b/hieradata/org/ncsa.yaml
@@ -31,7 +31,7 @@ docker::version: "19.03.4"
 #   - lsstts/label/dev
 #   - conda-forge
 
-pakrat_client::default_snapshot: "2020-02-19-1582151101"
+pakrat_client::default_snapshot: "2021-02-22-1614032701"
 pakrat_client::default_yumserver_url: "http://lsst-repos01.ncsa.illinois.edu"
 pakrat_client::repos:
   base:

--- a/hieradata/org/ncsa/role/puppet_master.yaml
+++ b/hieradata/org/ncsa/role/puppet_master.yaml
@@ -7,3 +7,9 @@ classes:
   - "::profile::ncsa::puppet_master"
   - "::profile::ncsa::system_authnz"
   - "::profile::ncsa::xcat_client"
+
+profile::ncsa::puppet_master::firewall_allow_from:
+  - "141.142.182.64/27"
+  - "141.142.238.0/24"
+
+python::version: "python36"

--- a/site/profile/manifests/docker.pp
+++ b/site/profile/manifests/docker.pp
@@ -33,7 +33,7 @@ class profile::docker {
     'OUTPUT:nat:IPv4',
     'PREROUTING:nat:IPv4',
   ]
-  $name_ignores = $docker_names + [ 'docker' ]
+  $name_ignores = $docker_names + [ 'docker', '-o br-', '-i br-' ]
 
   $name_ip_ignore_chains = [ 'POSTROUTING:nat:IPv4' ]
   $name_ip_ignores = $docker_names + [ '172.17', '172.18', '172.19' ]


### PR DESCRIPTION
- update pakrat_client::default_snapshot for OS updates on NCSA hosts
- use python36 for org/ncsa/puppet_master
- allow nts hosts through firewall for profile::ncsa::puppet_master
- update docker firewall exceptions