### PR TITLE
hiera: add rh-git218 to ccs clusters

### DIFF
--- a/hieradata/cluster/auxtel-ccs.yaml
+++ b/hieradata/cluster/auxtel-ccs.yaml
@@ -23,6 +23,7 @@ packages:
   - "maven"
   - "centos-release-scl-rh"
   - "devtoolset-8"
+  - "rh-git218"
 
 ## atsccs1 (at least) needs this, not sure why some hosts do and some don't.
 postfix::inet_protocols: "ipv4"

--- a/hieradata/cluster/comcam-ccs.yaml
+++ b/hieradata/cluster/comcam-ccs.yaml
@@ -23,6 +23,7 @@ packages:
   - "maven"
   - "centos-release-scl-rh"
   - "devtoolset-8"
+  - "rh-git218"
 
 postfix::manage_root_alias: false
 postfix::inet_protocols: "ipv4"

--- a/hieradata/cluster/pathfinder-ccs.yaml
+++ b/hieradata/cluster/pathfinder-ccs.yaml
@@ -14,6 +14,7 @@ packages:
   - "maven"
   - "centos-release-scl-rh"
   - "devtoolset-8"
+  - "rh-git218"
 
 postfix::manage_root_alias: false
 postfix::inet_interfaces: "localhost"

--- a/site/profile/files/ccs/profile_d/lsst-ccs.sh
+++ b/site/profile/files/ccs/profile_d/lsst-ccs.sh
@@ -10,3 +10,5 @@ export OMP_NUM_THREADS=1
 _dir=/lsst/ccs/prod/bin
 [ -e $_dir ] && [[ $PATH != *$_dir* ]] && PATH=$_dir:$PATH
 unset _dir
+
+[ ! -e /opt/rh/rh-git218 ] || source scl_source enable rh-git218


### PR DESCRIPTION
Installs the rh-git218 package from the centos-release-scl-rh repository