### PR TITLE
change  comcam-arctl01 & comcam-mcm dds interface dhcp -> static ip

### DIFF
--- a/hieradata/node/comcam-arctl01.cp.lsst.org.yaml
+++ b/hieradata/node/comcam-arctl01.cp.lsst.org.yaml
@@ -21,8 +21,10 @@ network::interfaces_hash:
     onboot: "yes"
     type: "Ethernet"
   em2:  # dds
-    bootproto: "dhcp"
+    bootproto: "none"
     defroute: "no"
+    ipaddress: "139.229.166.1"
+    netmask: "255.255.255.0"
     nozeroconf: "yes"
     onboot: "yes"
     type: "Ethernet"

--- a/hieradata/node/comcam-mcm.cp.lsst.org.yaml
+++ b/hieradata/node/comcam-mcm.cp.lsst.org.yaml
@@ -6,8 +6,10 @@ network::interfaces_hash:
     onboot: "yes"
     type: "Ethernet"
   em2:  # dds
-    bootproto: "dhcp"
+    bootproto: "none"
     defroute: "no"
+    ipaddress: "139.229.170.11"
+    netmask: "255.255.255.0"
     nozeroconf: "yes"
     onboot: "yes"
     type: "Ethernet"


### PR DESCRIPTION
These hosts appear to be loosing their static dds routes when the dhcp configured dds interface bounces.