### PR TITLE
Bump ccs_sal module version to 0.5.0

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -120,7 +120,7 @@ mod 'lsst/ccs_mrtg',
   ref: 'v0.1.1'
 mod 'lsst/ccs_sal',
   git: 'https://github.com/lsst-it/puppet-ccs_sal.git',
-  ref: 'v0.3.5'
+  ref: 'v0.5.0'
 mod 'lsst/ccs_software',
   git: 'https://github.com/lsst-it/puppet-ccs_software.git',
   ref: 'v0.5.0'


### PR DESCRIPTION
This fetches rpms from nexus instead of slac.