### PR TITLE
IT-3024 update docker nat ignore rules for puppet firewall

### DIFF
--- a/site/profile/manifests/docker.pp
+++ b/site/profile/manifests/docker.pp
@@ -36,7 +36,7 @@ class profile::docker {
   $name_ignores = $docker_names + [ 'docker', '-o br-', '-i br-' ]
 
   $name_ip_ignore_chains = [ 'POSTROUTING:nat:IPv4' ]
-  $name_ip_ignores = $docker_names + [ '172.17', '172.18', '172.19' ]
+  $name_ip_ignores = $docker_names + [ '-s 172\.', '-d 172\.' ]
 
 
   firewallchain {


### PR DESCRIPTION
Updates to prevent puppet firewall from removing NAT rules created by docker.