### PR TITLE
add .conf to systemd::tmpfile resource names

### DIFF
--- a/hieradata/org/lsst/role/archiver.yaml
+++ b/hieradata/org/lsst/role/archiver.yaml
@@ -125,5 +125,5 @@ sudo::configs:
 nfs::server_enabled: true
 
 profile::core::systemd::tmpfile:
-  docker_tmp:  # XXX short term kludge
+  docker_tmp.conf:  # XXX short term kludge
     content: "d /tmp/docker_tmp 0777 saluser saluser -"

--- a/hieradata/org/lsst/role/atsccs.yaml
+++ b/hieradata/org/lsst/role/atsccs.yaml
@@ -16,5 +16,5 @@ nfs::client_mounts:
 ccs_monit::hwraid: false
 
 profile::core::systemd::tmpfile:
-  docker_tmp:  # XXX short term kludge
+  docker_tmp.conf:  # XXX short term kludge
     content: "d /tmp/docker_tmp 0777 saluser saluser -"

--- a/hieradata/org/lsst/role/ccs-mcm.yaml
+++ b/hieradata/org/lsst/role/ccs-mcm.yaml
@@ -20,5 +20,5 @@ profile::ccs::tomcat::wars:
     war_source: "https://repo-nexus.lsst.org/nexus/repository/ccs-maven2-snapshots/org/lsst/CCSWebTrending/2.1-SNAPSHOT/CCSWebTrending-2.1-20200623.212832-4.war"
 
 profile::core::systemd::tmpfile:
-  docker_tmp:  # XXX short term kludge
+  docker_tmp.conf:  # XXX short term kludge
     content: "d /tmp/docker_tmp 0777 saluser saluser -"


### PR DESCRIPTION
To resolve this error message:

    Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Resource Statement, Systemd::Tmpfile[docker_tmp]: parameter 'filename' expects a match for Systemd::Dropin = Pattern[/^[^\/]+\.conf$/], got 'docker_tmp' (file: /etc/puppetlabs/code/environments/IT_3026_comcam_auxtel_software/site/profile/manifests/core/systemd.pp, line: 21) on node comcam-mcm.cp.lsst.org