### PR TITLE
remove "authoritative" statement from dhcp pools

### DIFF
--- a/hieradata/org/lsst/role/comcam-fp.yaml
+++ b/hieradata/org/lsst/role/comcam-fp.yaml
@@ -17,6 +17,7 @@ chrony::queryhosts:
 chrony::clientlog: true
 
 # dhcp for DAQ + clients
+dhcp::authoritative: true
 dhcp::interfaces:
   - "lsst-daq"
 dhcp::bootp: true
@@ -27,7 +28,6 @@ dhcp::pools:
     mask: "255.255.255.0"
     range: "192.168.100.2 192.168.100.254"
     pool_parameters:
-      - "authoritative"
       - "ddns-update-style none"
       - "default-lease-time -1"
       - "max-lease-time -1"

--- a/hieradata/org/lsst/role/daq-mgmt.yaml
+++ b/hieradata/org/lsst/role/daq-mgmt.yaml
@@ -22,7 +22,6 @@ dhcp::pools:
     mask: "255.255.255.0"
     range: "192.168.100.2 192.168.100.254"
     pool_parameters:
-      - "authoritative"
       - "ddns-update-style none"
       - "default-lease-time -1"
       - "max-lease-time -1"

--- a/hieradata/site/tu/role/foreman.yaml
+++ b/hieradata/site/tu/role/foreman.yaml
@@ -5,7 +5,7 @@ classes:
 profile::core::sysctl::rp_filter::enable: false
 dhcp::interfaces:
   - "eth0"
-dhcp::authoritative: false
+dhcp::authoritative: true
 dhcp::pxeserver: "140.252.146.80"
 # theforeman/dhcp 5.0.1 only supports `option domain-search` per pool
 dhcp::pools:


### PR DESCRIPTION
As this is a noop. Per `dhcpd.conf(5)`:
    Note  that  the  most  specific scope for which the concept of authority makes any
    sense is the physical network segment - either a  shared-network  statement  or  a
    subnet  statement  that is not contained within a shared-network statement.  It is
    not meaningful to specify that the server is authoritative for some subnets within
    a  shared network, but not authoritative for others, nor is it meaningful to spec‐
    ify that the server is authoritative for some host declarations and not others.