### PR TITLE
rm versionlocked kernel versions

### DIFF
--- a/hieradata/cluster/chonchon.yaml
+++ b/hieradata/cluster/chonchon.yaml
@@ -1,6 +1,5 @@
 ---
 clustershell::groupmembers:
   chonchon: {group: "chonchon", member: "chonchon[01-03]"}
-profile::core::kernel::version: "3.10.0-1160.15.2.el7.x86_64"
 profile::app::rke::version: "1.2.5"
 profile::app::helm::version: "3.5.2"

--- a/hieradata/cluster/pillan.yaml
+++ b/hieradata/cluster/pillan.yaml
@@ -8,7 +8,6 @@ docker::version: "19.03.15"
 profile::app::helm::version: "3.5.4"
 profile::app::rke::version: "1.2.9"
 profile::core::common::manage_powertop: true
-profile::core::kernel::version: "3.10.0-1160.36.2.el7.x86_64"
 profile::core::ospl::enable_rundir: true
 profile::core::rke::enable_dhcp: true
 

--- a/hieradata/cluster/ruka-workers.yaml
+++ b/hieradata/cluster/ruka-workers.yaml
@@ -28,5 +28,3 @@ yum::repos:
     baseurl: "https://repo-nexus.lsst.org/nexus/repository/dell/"
     gpgcheck: false
     target: "/etc/yum.repos.d/dell.repo"
-
-profile::core::kernel::version: "3.10.0-1160.11.1.el7.x86_64"

--- a/hieradata/cluster/ruka.yaml
+++ b/hieradata/cluster/ruka.yaml
@@ -36,5 +36,4 @@ yum::repos:
 # hieradata/org/lsst/role/rke.yaml. This pins the kernel to the currently
 # available version; in the long run we can host CentOS mirrors to ensure
 # the availability of this package.
-profile::core::kernel::version: "3.10.0-1127.8.2.el7.x86_64"
 profile::app::helm::version: "3.5.4"

--- a/hieradata/cluster/vk8s.yaml
+++ b/hieradata/cluster/vk8s.yaml
@@ -4,4 +4,3 @@ clustershell::groupmembers:
 docker::version: "19.03.15"
 profile::app::helm::version: "3.5.4"
 profile::app::rke::version: "1.2.8"
-profile::core::kernel::version: "3.10.0-1127.8.2.el7.x86_64"

--- a/hieradata/node/sal-dx.cp.lsst.org.yaml
+++ b/hieradata/node/sal-dx.cp.lsst.org.yaml
@@ -10,5 +10,4 @@ network::interfaces_hash:
     type: "Ethernet"
     mtu: "9000"
 
-profile::core::kernel::version: "3.10.0-1127.8.2.el7.x86_64"
 profile::ccs::sal_dx::username: "lsst_jenkins"

--- a/hieradata/org/lsst/role/icinga-master.yaml
+++ b/hieradata/org/lsst/role/icinga-master.yaml
@@ -10,8 +10,6 @@ packages:
   - "bash-completion-extras"
   - "vim"
 
-profile::core::kernel::version: "3.10.0-1127.8.2.el7.x86_64"
-
 #LDAP Values
 profile::icinga::master::ldap_server: "139.229.135.6"
 profile::icinga::master::ldap_root: "cn=accounts,dc=lsst,dc=cloud"

--- a/hieradata/org/lsst/role/rke.yaml
+++ b/hieradata/org/lsst/role/rke.yaml
@@ -47,7 +47,6 @@ profile::app::helm::version: "3.0.3"
 profile::app::rke::version: "1.0.4"
 profile::core::kernel::devel: true
 profile::core::kernel::debuginfo: true
-profile::core::kernel::version: "3.10.0-1062.12.1.el7.x86_64"
 
 files:
   /home/rke/.bash_profile:

--- a/hieradata/site/tu/cluster/rancher.yaml
+++ b/hieradata/site/tu/cluster/rancher.yaml
@@ -2,4 +2,3 @@
 docker::version: "19.03.15"
 profile::app::helm::version: "3.5.4"
 profile::app::rke::version: "1.2.8"
-profile::core::kernel::version: "3.10.0-1160.36.2.el7.x86_64"


### PR DESCRIPTION
In preparation for a planned batch security update.  To be replaced with
a global kernel versionlock.