### PR TITLE
cleanup centos yum repo names

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -88,6 +88,7 @@ mod 'puppetlabs/augeas_core', '1.1.1'
 mod 'camptocamp/openldap', '2.0.0'
 mod 'lsst/cni', '1.0.0'
 mod 'treydock/clustershell', '1.0.0'
+mod 'puppetlabs/yumrepo_core', '1.0.7'
 
 # latest puppet/letsencrypt release does not include dns_route53 plugin support
 mod 'puppet/letsencrypt',

--- a/site/profile/data/org/lsst.yaml
+++ b/site/profile/data/org/lsst.yaml
@@ -51,33 +51,33 @@ profile::ts::nexusctio::repos:
 
 profile::core::yum::centos::repos:
   base:
+    descr: "CentOS-$releasever - Base"
     enabled: true
     ensure: "present"
     gpgcheck: true
     gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7"
     mirrorlist: "http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra"
-    name: "CentOS-$releasever - Base"
     target: "/etc/yum.repos.d/CentOS-Base.repo"
   updates:
+    descr: "CentOS-$releasever - Updates"
     enabled: true
     ensure: "present"
     gpgcheck: true
     gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7"
     mirrorlist: "http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra"
-    name: "CentOS-$releasever - Updates"
     target: "/etc/yum.repos.d/CentOS-Base.repo"
   extras:
+    descr: "CentOS-$releasever - Extras"
     enabled: true
     ensure: "present"
     gpgcheck: true
     gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7"
     mirrorlist: "http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras&infra=$infra"
-    name: "CentOS-$releasever - Extras"
     target: "/etc/yum.repos.d/CentOS-Base.repo"
   base-debuginfo:
     baseurl: "http://debuginfo.centos.org/7/$basearch/"
+    descr: "CentOS-7 - Debuginfo"
     enabled: false
     gpgcheck: true
     gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-Debug-7"
-    name: "CentOS-7 - Debuginfo"
     target: "/etc/yum.repos.d/CentOS-Debuginfo.repo"

--- a/site/profile/data/org/lsst.yaml
+++ b/site/profile/data/org/lsst.yaml
@@ -50,7 +50,7 @@ profile::ts::nexusctio::repos:
     target: "/etc/yum.repos.d/gpgmsoo.repo"
 
 profile::core::yum::centos::repos:
-  base:
+  centos-base:
     descr: "CentOS-$releasever - Base"
     enabled: true
     ensure: "present"
@@ -58,7 +58,7 @@ profile::core::yum::centos::repos:
     gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7"
     mirrorlist: "http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=os&infra=$infra"
     target: "/etc/yum.repos.d/CentOS-Base.repo"
-  updates:
+  centos-updates:
     descr: "CentOS-$releasever - Updates"
     enabled: true
     ensure: "present"
@@ -66,7 +66,7 @@ profile::core::yum::centos::repos:
     gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7"
     mirrorlist: "http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra"
     target: "/etc/yum.repos.d/CentOS-Base.repo"
-  extras:
+  centos-extras:
     descr: "CentOS-$releasever - Extras"
     enabled: true
     ensure: "present"
@@ -74,7 +74,7 @@ profile::core::yum::centos::repos:
     gpgkey: "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7"
     mirrorlist: "http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras&infra=$infra"
     target: "/etc/yum.repos.d/CentOS-Base.repo"
-  base-debuginfo:
+  centos-base-debuginfo:
     baseurl: "http://debuginfo.centos.org/7/$basearch/"
     descr: "CentOS-7 - Debuginfo"
     enabled: false


### PR DESCRIPTION
Per https://github.com/puppetlabs/puppetlabs-yumrepo_core/blob/main/lib/puppet/type/yumrepo.rb#L41-L45, the `yumrepo` `target` parameter does not do anything.