### PR TITLE
(puppetdb role) bump puppetdb to 6.18.0

### DIFF
--- a/hieradata/org/lsst/role/puppetdb.yaml
+++ b/hieradata/org/lsst/role/puppetdb.yaml
@@ -16,10 +16,10 @@ postgresql::globals::server_package_name: "rh-postgresql12-postgresql-server-sys
 postgresql::globals::service_name: "postgresql"
 postgresql::globals::version: "12"
 profile::core::yum::versionlock:
-  0:puppetdb-6.16.1-1.el7.noarch:
+  0:puppetdb-6.18.0-1.el7.noarch:
     ensure: "present"
 puppetdb::database_listen_address: "localhost"
-puppetdb::globals::version: "6.16.1"
+puppetdb::globals::version: "6.18.0"
 puppetdb::java_args:
   "-Xmx": "1g"
   "-Xms": "512m"


### PR DESCRIPTION
Note that puppetdb-termini is staying at 6.16.1.