### PR TITLE
IT-3127 NCSA OS snapshot 2021-07-22-1626989101

### DIFF
--- a/hieradata/org/ncsa.yaml
+++ b/hieradata/org/ncsa.yaml
@@ -31,7 +31,7 @@ docker::version: "19.03.4"
 #   - lsstts/label/dev
 #   - conda-forge
 
-pakrat_client::default_snapshot: "2021-06-16-1623878701"
+pakrat_client::default_snapshot: "2021-07-22-1626989101"
 pakrat_client::default_yumserver_url: "http://lsst-repos01.ncsa.illinois.edu"
 pakrat_client::repos:
   base:


### PR DESCRIPTION
One line hiera change
`pakrat_client::default_snapshot: "2021-07-22-1626989101"`
to update the OS snapshot to the same as in IHS-4991