### PR TITLE
fix docker daemon startup issues

### DIFF
--- a/hieradata/site/tu.yaml
+++ b/hieradata/site/tu.yaml
@@ -30,3 +30,8 @@ profile::core::common::deploy_icinga_agent: false
 profile::core::common::manage_powertop: true
 
 tuned::profile: "powersave"
+
+profile::core::docker::version: "20.10.9"
+profile::core::docker::versionlock:
+  - "1:docker-ce-cli-20.10.9-3.el7.*"
+  - "3:docker-ce-20.10.9-3.el7.*"

--- a/site/profile/data/org/lsst.yaml
+++ b/site/profile/data/org/lsst.yaml
@@ -134,3 +134,8 @@ profile::core::yum::lsst_ts_private::repos:
     ensure: "present"
     gpgcheck: false
     target: "/etc/yum.repos.d/lsst-ts-private.repo"
+
+profile::core::docker::version: "19.03.15"
+profile::core::docker::versionlock:
+  - "1:docker-ce-cli-19.03.15-3.el7.x86_64"
+  - "3:docker-ce-19.03.15-3.el7.x86_64"

--- a/site/profile/manifests/core/docker.pp
+++ b/site/profile/manifests/core/docker.pp
@@ -7,21 +7,17 @@
 # @param socket_group
 #   gid for docker named pipe
 #
-# @param docker_ce_package
-#   complete package string for versionlock
-#
-# @param docker_ce_cli_package
-#   complete package string for versionlock
-#
 # @param storage_driver
 #   name of docker storage driver to use
 #
+# @param versionlock
+#   Array of yum::versionlock resources to create
+#
 class profile::core::docker (
-  Optional[String] $version     = '19.03.15',
-  String $socket_group          = '70014',
-  String $docker_ce_package     = 'docker-ce-19.03.15-3.el7.x86_64',
-  String $docker_ce_cli_package = 'docker-ce-cli-19.03.15-3.el7.x86_64',
-  String $storage_driver        = 'overlay2',
+  Optional[String] $version,
+  String $socket_group                 = '70014',
+  String $storage_driver               = 'overlay2',
+  Optional[Array[String]] $versionlock = undef,
 ) {
   class { 'docker':
     overlay2_override_kernel_check => true,  # needed on el7
@@ -31,10 +27,11 @@ class profile::core::docker (
     version                        => $version,
   }
 
-  yum::versionlock { [
-      "3:${docker_ce_package}",
-      "1:${docker_ce_cli_package}",
-    ]:
+  if $versionlock {
+    include yum::plugin::versionlock
+
+    yum::versionlock { [$versionlock]:
       ensure => present,
+    }
   }
 }

--- a/spec/classes/core/docker_spec.rb
+++ b/spec/classes/core/docker_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'profile::core::docker' do
+  let(:node_params) { { org: 'lsst' } }
+
+  it { is_expected.to compile.with_all_deps }
+
+  it do
+    is_expected.to contain_class('docker').with(
+      overlay2_override_kernel_check: true,
+      socket_group: 70_014,
+      socket_override: true,
+      storage_driver: 'overlay2',
+      version: '19.03.15',
+    )
+  end
+
+  it { is_expected.to contain_class('yum::plugin::versionlock') }
+  it { is_expected.to have_yum__versionlock_resource_count(2) }
+
+  context 'when site tu' do
+    let(:node_params) do
+      super().merge(
+        site: 'tu',
+      )
+    end
+
+    it { is_expected.to contain_class('docker').with(version: '20.10.9') }
+  end
+end


### PR DESCRIPTION
The docker.socket systemd unit has been observed to failing to start on boot on  
a freshly provisioned host in Tucson. This was resolved by updating to docker  
20.10.9. The root cause is not understood. The suspicion is that this is an  
interaction of 2019 vintage docker-ce package with recent el7 systemd changes.