### PR TITLE
add docker::networks to profile::core::docker

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -37,7 +37,9 @@ mod 'camptocamp/postfix', '1.8.0'
 mod 'camptocamp/augeas', '1.8.0'
 mod 'puppet/alternatives', '3.0.0'
 mod 'puppetlabs/mailalias_core', '1.0.5'
-mod 'puppetlabs/docker', '4.1.0'
+mod 'puppetlabs/docker',
+  git: 'https://github.com/lsst-it/puppetlabs-docker.git',
+  ref: 'production'
 mod 'puppetlabs/reboot', '2.2.0'
 mod 'puppet/python', '3.0.1'
 mod 'derdanne/nfs', '2.1.2'

--- a/hieradata/org/lsst/role/amor.yaml
+++ b/hieradata/org/lsst/role/amor.yaml
@@ -1,6 +1,5 @@
 ---
 classes:
-  - "docker::networks"
   - "profile::core::common"
   - "profile::core::debugutils"
   - "profile::core::docker"

--- a/hieradata/org/lsst/role/ts-csc.yaml
+++ b/hieradata/org/lsst/role/ts-csc.yaml
@@ -4,7 +4,6 @@ classes:
   - "profile::core::docker"
   - "profile::core::docker::prune"
   - "profile::nfs::client::csc"
-  - "docker::networks"
   - "python"
 
 packages:

--- a/site/profile/manifests/core/docker.pp
+++ b/site/profile/manifests/core/docker.pp
@@ -19,6 +19,8 @@ class profile::core::docker (
   String $storage_driver               = 'overlay2',
   Optional[Array[String]] $versionlock = undef,
 ) {
+  include docker::networks
+
   class { 'docker':
     overlay2_override_kernel_check => true,  # needed on el7
     socket_group                   => $socket_group,

--- a/spec/classes/core/docker_spec.rb
+++ b/spec/classes/core/docker_spec.rb
@@ -19,6 +19,7 @@ describe 'profile::core::docker' do
 
   it { is_expected.to contain_class('yum::plugin::versionlock') }
   it { is_expected.to have_yum__versionlock_resource_count(2) }
+  it { is_expected.to contain_class('docker::networks') }
 
   context 'when site tu' do
     let(:node_params) do

--- a/spec/hosts/roles/amor_spec.rb
+++ b/spec/hosts/roles/amor_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'test1.dev.lsst.org', :site do
+  describe 'amor role' do
+    lsst_sites.each do |site|
+      context "with site #{site}" do
+        let(:node_params) do
+          {
+            org: 'lsst',
+            site: site,
+            role: 'amor',
+            cluster: 'amor',
+            ipa_force_join: false, # easy_ipa
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+
+        it { is_expected.to contain_class('docker::networks') }
+      end
+    end # site
+  end # role
+end

--- a/spec/hosts/roles/docker_compose_spec.rb
+++ b/spec/hosts/roles/docker_compose_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'test1.dev.lsst.org', :site do
+  describe 'docker-compose role' do
+    lsst_sites.each do |site|
+      context "with site #{site}" do
+        let(:node_params) do
+          {
+            org: 'lsst',
+            site: site,
+            role: 'docker-compose',
+            cluster: 'azar',
+            ipa_force_join: false, # easy_ipa
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+
+        it { is_expected.to contain_class('docker') }
+        it { is_expected.to contain_class('docker::networks') }
+      end
+    end # site
+  end # role
+end

--- a/spec/hosts/roles/ts_csc_spec.rb
+++ b/spec/hosts/roles/ts_csc_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'test1.dev.lsst.org', :site do
+  describe 'ts-csc role' do
+    lsst_sites.each do |site|
+      context "with site #{site}" do
+        let(:node_params) do
+          {
+            org: 'lsst',
+            site: site,
+            role: 'ts-csc',
+            cluster: 'trewa',
+            ipa_force_join: false, # easy_ipa
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+
+        it { is_expected.to contain_class('docker::networks') }
+      end
+    end # site
+  end # role
+end


### PR DESCRIPTION
To allow docker::networks::networks to be defined in hiera, as needed, without additional modification to the manifest.