### PR TITLE
hiera: add the h2db service on comcam-fp01.tu

### DIFF
--- a/hieradata/node/comcam-fp01.tu.lsst.org.yaml
+++ b/hieradata/node/comcam-fp01.tu.lsst.org.yaml
@@ -46,5 +46,4 @@ ccs_software::services:
   prod:
     - "comcam-fp"
     - "comcam-ih"
-    ## Non-standard ExecStart:
-#    - "h2db"
+    - "h2db"


### PR DESCRIPTION
Since tonyj created /opt/lsst/ccs/prod/bin/h2db, we can now use a
standard service file for this.