### PR TITLE
Bump ccs_software module version

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -133,7 +133,7 @@ mod 'lsst/ccs_sal',
   ref: 'v0.7.1'
 mod 'lsst/ccs_software',
   git: 'https://github.com/lsst-it/puppet-ccs_software.git',
-  ref: 'v0.6.1'
+  ref: 'v0.8.0'
 mod 'lsst/maven',
   git: 'https://github.com/lsst-it/puppet-maven.git',
   ref: 'v1.0.0'

--- a/hieradata/cluster/auxtel-ccs.yaml
+++ b/hieradata/cluster/auxtel-ccs.yaml
@@ -53,6 +53,8 @@ ccs_software::jdk8::package: "jdk1.8"
 ccs_software::jdk8::dir: "jdk1.8.0_202-amd64"
 ccs_software::jdk8::version: "2000:1.8.0_202-fcs"
 
+ccs_software::service_email: "auxtel-ccs-alerts-aaaadjkgtdl6pb2omvdi732xci@lsstc.slack.com"
+
 clustershell::groupmembers:
   misc: {group: "misc", member: "atsccs[1-2],atsdaq1"}
   hcu: {group: "hcu", member: "atshcu1"}

--- a/hieradata/cluster/comcam-ccs.yaml
+++ b/hieradata/cluster/comcam-ccs.yaml
@@ -83,6 +83,9 @@ ccs_software::global_properties:
   - "org.lsst.ccs.subsystem.agent.property.cluster=%{lookup('ccs_instrument')}"
   - "org.lsst.ccs.subsystem.agent.property.site=%{lookup('ccs_site')}"
 
+## comcam-alerts
+ccs_software::service_email: "x7z0x9c0t2k4r1n1@lsstc.slack.com"
+
 ccs_monit::mailhost: "mail.lsst.org"
 ccs_monit::alert:
   ## comcam-alerts

--- a/hieradata/site/tu/cluster/auxtel-ccs.yaml
+++ b/hieradata/site/tu/cluster/auxtel-ccs.yaml
@@ -2,6 +2,8 @@
 ccs_site: "tucson"
 ccs_sal::dds_interface: "auxtel-mcm-dds.tu.lsst.org"
 
+ccs_software::service_email: "tucson-teststand-aler-aaaae4zsdubhmm3n7mowaugr2y@lsstc.slack.com"
+
 ccs_monit::alert:
   ## tucson-teststand-alerts
   - "tucson-teststand-aler-aaaae4zsdubhmm3n7mowaugr2y@lsstc.slack.com"

--- a/hieradata/site/tu/cluster/comcam-ccs.yaml
+++ b/hieradata/site/tu/cluster/comcam-ccs.yaml
@@ -2,6 +2,8 @@
 ccs_site: "tucson"
 ccs_sal::dds_interface: "comcam-mcm-dds.tu.lsst.org"
 
+ccs_software::service_email: "tucson-teststand-aler-aaaae4zsdubhmm3n7mowaugr2y@lsstc.slack.com"
+
 ccs_monit::alert:
   ## tucson-teststand-alerts
   - "tucson-teststand-aler-aaaae4zsdubhmm3n7mowaugr2y@lsstc.slack.com"


### PR DESCRIPTION
This version produces alerts when a ccs systemd service fails.
Add the corresponding hiera config for the alert email address.