### PR TITLE
DM-32881 bump NCSA default OS snapshot

### DIFF
--- a/hieradata/org/ncsa.yaml
+++ b/hieradata/org/ncsa.yaml
@@ -31,7 +31,7 @@ docker::version: "19.03.4"
 #   - lsstts/label/dev
 #   - conda-forge
 
-pakrat_client::default_snapshot: "2021-09-12-1631481901"
+pakrat_client::default_snapshot: "2021-12-06-1638818960"
 pakrat_client::default_yumserver_url: "http://lsst-repos01.ncsa.illinois.edu"
 pakrat_client::repos:
   base:


### PR DESCRIPTION
Affects nodes

- lsst-nts-ccheader.ncsa.illinois.edu
- lsst-nts.csc1.ncsa.illinois.edu

Change are tested and applied to the nodes. This merge just get's rid of the branch and allows moving the `ncsa_production` pointer forward.