### PR TITLE
(profile::core::dtn) rm tql_tunning service; replace with NM dispatch

### DIFF
--- a/hieradata/node/dtn01.ls.lsst.org.yaml
+++ b/hieradata/node/dtn01.ls.lsst.org.yaml
@@ -22,3 +22,8 @@ network::interfaces_hash:
     netmask: "255.255.255.254"
     nozeroconf: "yes"
     mtu: "9000"
+profile::core::nm_dispatch::interfaces:
+  enp6s0:
+    - "/sbin/ip link set ${DEV} txqueuelen 20000"
+    - "/sbin/ethtool --features ${DEV} lro on"
+    - "/sbin/ethtool --set-ring ${DEV} rx 8192 tx 8192"

--- a/site/profile/manifests/core/dtn.pp
+++ b/site/profile/manifests/core/dtn.pp
@@ -23,33 +23,4 @@ class profile::core::dtn (
   service { 'irqbalance':
     ensure => 'stopped'
   }
-
-  # Transmit Queue Lenght at boot
-  file { '/usr/local/bin/tql_tunning':
-    ensure  => 'present',
-    mode    => '0755',
-    content => @(TQL/L)
-      #!/bin/bash
-      ip link set enp6s0 txqueuelen 20000
-      ethtool -K enp6s0 lro on
-      ethtool -G enp6s0 rx 8192 tx 8192
-      | TQL
-  }
-  -> systemd::unit_file { 'tql_tunning.service':
-    enable  => true,
-    active  => true,
-    content => @(SERVICE/L)
-      [Unit]
-      Description=Network Interfaces Tunning
-      After=network.target
-
-      [Service]
-      Type=simple
-      ExecStart=/usr/local/bin/tql_tunning
-      TimeoutStartSec=0
-
-      [Install]
-      WantedBy=default.target
-      | SERVICE
-  }
 }

--- a/site/profile/manifests/core/dtn.pp
+++ b/site/profile/manifests/core/dtn.pp
@@ -33,7 +33,6 @@ class profile::core::dtn (
       ip link set enp6s0 txqueuelen 20000
       ethtool -K enp6s0 lro on
       ethtool -G enp6s0 rx 8192 tx 8192
-      cpupower frequency-set --governor performance
       | TQL
   }
   -> systemd::unit_file { 'tql_tunning.service':


### PR DESCRIPTION
The `tql_tunning` service is being invoked on every puppet run.  This is
undesirable as it makes it appear if the puppet state on the node is
not converged.  Running interface tuning commands as a one-off is also
undesirable as parameters may be lost when the interface goes up and
down.  The NM dispatch script hooks are a more reliable option.
Additionally, interface name specific configuration generally should not
be baked into a profile class as it is inherently tied to a hosts
hardware.