### PR TITLE
(hexrot role) disable ctio nexus yum repos; hostname does not exist

### DIFF
--- a/hieradata/org/lsst/role/hexrot.yaml
+++ b/hieradata/org/lsst/role/hexrot.yaml
@@ -6,7 +6,6 @@ classes:
   - "profile::core::docker::prune"
   - "profile::core::ni_packages"
   - "profile::core::x2go_agent"
-  - "profile::ts::nexusctio"
   - "python"
 packages:
   - "runHexEui"

--- a/spec/hosts/roles/hexrot_spec.rb
+++ b/spec/hosts/roles/hexrot_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'test1.dev.lsst.org', :site do
+  role = 'hexrot'
+  let(:role) { role }
+
+  describe "#{role} role" do
+    lsst_sites.each do |site|
+      context "with site #{site}" do
+        let(:node_params) do
+          {
+            org: 'lsst',
+            site: site,
+            role: role,
+            ipa_force_join: false, # easy_ipa
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+
+        %w[
+          profile::core::common
+          profile::core::debugutils
+          profile::core::docker
+          profile::core::docker::prune
+          profile::core::ni_packages
+          profile::core::x2go_agent
+          python
+        ].each do |c|
+          it { is_expected.to contain_class(c) }
+        end
+
+        it { is_expected.not_to contain_class('profile::ts::nexusctio') }
+      end
+    end # site
+  end # role
+end


### PR DESCRIPTION
    http://cagvm3.ctio.noao.edu/nexus/repository/gpg-rpm/MSO/repodata/repomd.xml: [Errno 14] curl#6 - "Could not resolve host: cagvm3.ctio.noao.edu; Unknown error"
    Trying other mirror.

     One of the configured repositories failed (Nexus GPG MSO Repository),
     and yum doesn't have enough cached data to continue. At this point the only
     safe thing yum can do is fail. There are a few ways to work "fix" this:

         1. Contact the upstream for the repository and get them to fix the problem.

         2. Reconfigure the baseurl/etc. for the repository, to point to a working
        upstream. This is most often useful if you are using a newer
        distribution release than is supported by the repository (and the
        packages for the previous distribution release still work).

         3. Run the command with the repository temporarily disabled
            yum --disablerepo=gpgmso ...

         4. Disable the repository permanently, so yum won't use it by default. Yum
        will then just ignore the repository until you permanently enable it
        again or use --enablerepo for temporary usage:

            yum-config-manager --disable gpgmso
        or
            subscription-manager repos --disable=gpgmso

         5. Configure the failing repository to be skipped, if it is unavailable.
        Note that yum will try to contact the repo. when it runs most commands,
        so will have to try and fail each time (and thus. yum will be be much
        slower). If it is a very temporary problem though, this is often a nice
        compromise:

            yum-config-manager --save --setopt=gpgmso.skip_if_unavailable=true

    failure: repodata/repomd.xml from gpgmso: [Errno 256] No more mirrors to try.