### PR TITLE
attempt to improve NVMe hotplug on Supermicro 1114S-WN10RT

### DIFF
--- a/site/profile/manifests/core/hardware.pp
+++ b/site/profile/manifests/core/hardware.pp
@@ -17,6 +17,10 @@ class profile::core::hardware {
       include profile::core::kernel::pcie_aspm
       # apst is suspected of causing problems with NVMes
       include profile::core::kernel::nvme_apst
+      # attempt to improve NVMe hotplug support on el7
+      profile::util::kernel_param { 'pci=pcie_bus_perf':
+        reboot => false,
+      }
     }
   }
   # lint:endignore

--- a/site/profile/manifests/util/kernel_param.pp
+++ b/site/profile/manifests/util/kernel_param.pp
@@ -4,15 +4,25 @@
 # @param name
 #   Kernel parameter string. E.g.: `systemd.unified_cgroup_hierarchy=0`
 #
-define profile::util::kernel_param {
+# @param reboot
+#   Whether or not to force a reboot to ensure kernel parameter is set on the running kernel.
+#   Defaults to `true`.
+#
+define profile::util::kernel_param (
+  Boolean $reboot = true,
+) {
   $message = "set kernel parameter: ${name}"
 
   kernel_parameter { $name:
     ensure => present,
   }
-  ~> reboot { $name:
-    apply   => finished,
-    message => $message,
-    when    => refreshed,
+
+  if ($reboot) {
+    reboot { $name:
+      apply     => finished,
+      message   => $message,
+      when      => refreshed,
+      subscribe => Kernel_parameter[$name],
+    }
   }
 }

--- a/spec/classes/core/hardware_spec.rb
+++ b/spec/classes/core/hardware_spec.rb
@@ -26,6 +26,7 @@ describe 'profile::core::hardware' do
       it { is_expected.not_to contain_class('profile::core::perccli') }
       it { is_expected.not_to contain_class('profile::core::kernel::pcie_aspm') }
       it { is_expected.not_to contain_class('profile::core::kernel::nvme_apst') }
+      it { is_expected.not_to contain_profile__util__kernel_param('pci=pcie_bus_perf') }
     end
 
     context 'with fact has_dellperc: true' do
@@ -36,6 +37,7 @@ describe 'profile::core::hardware' do
       it { is_expected.to contain_class('profile::core::perccli') }
       it { is_expected.not_to contain_class('profile::core::kernel::pcie_aspm') }
       it { is_expected.not_to contain_class('profile::core::kernel::nvme_apst') }
+      it { is_expected.not_to contain_profile__util__kernel_param('pci=pcie_bus_perf') }
     end
   end  # PowerEdge
 
@@ -58,6 +60,11 @@ describe 'profile::core::hardware' do
       it { is_expected.not_to contain_class('profile::core::perccli') }
       it { is_expected.to contain_class('profile::core::kernel::pcie_aspm') }
       it { is_expected.to contain_class('profile::core::kernel::nvme_apst') }
+
+      it do
+        is_expected.to contain_profile__util__kernel_param('pci=pcie_bus_perf')
+          .with_reboot(false)
+      end
     end
 
     context 'with fact has_dellperc: true' do
@@ -68,6 +75,11 @@ describe 'profile::core::hardware' do
       it { is_expected.not_to contain_class('profile::core::perccli') }
       it { is_expected.to contain_class('profile::core::kernel::pcie_aspm') }
       it { is_expected.to contain_class('profile::core::kernel::nvme_apst') }
+
+      it do
+        is_expected.to contain_profile__util__kernel_param('pci=pcie_bus_perf')
+          .with_reboot(false)
+      end
     end
   end  # 1114S-WN10RT
 end

--- a/spec/defines/util/kernel_param_spec.rb
+++ b/spec/defines/util/kernel_param_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'profile::util::kernel_param' do
+  let(:title) { 'foo' }
+
+  it { is_expected.to compile.with_all_deps }
+
+  context 'with no params' do
+    it do
+      is_expected.to contain_kernel_parameter(title).with(
+        ensure: 'present',
+      )
+    end
+
+    it do
+      is_expected.to contain_reboot(title).with(
+        apply: 'finished',
+        message: "set kernel parameter: #{title}",
+        when: 'refreshed',
+      )
+    end
+
+    it do
+      is_expected.to contain_reboot(title).that_subscribes_to("Kernel_parameter[#{title}]")
+    end
+  end
+
+  context 'with reboot => true' do
+    let(:params) { { reboot: true } }
+
+    it do
+      is_expected.to contain_kernel_parameter(title).with(
+        ensure: 'present',
+      )
+    end
+
+    it do
+      is_expected.to contain_reboot(title).with(
+        apply: 'finished',
+        message: "set kernel parameter: #{title}",
+        when: 'refreshed',
+      )
+    end
+
+    it do
+      is_expected.to contain_reboot(title).that_subscribes_to("Kernel_parameter[#{title}]")
+    end
+  end
+
+  context 'with reboot => false' do
+    let(:params) { { reboot: false } }
+
+    it do
+      is_expected.to contain_kernel_parameter(title).with(
+        ensure: 'present',
+      )
+    end
+
+    it { is_expected.not_to contain_reboot(title) }
+  end
+end


### PR DESCRIPTION
Without forcing a reboot to apply this kernel parameter.  We aren't even sure yet if this will be a helpful change as, anecdotally, NVMe hotplug will always be unreliable on EL7. 