### PR TITLE
(profile::core::docker) start docker.service after sssd.service

### DIFF
--- a/spec/classes/core/docker_spec.rb
+++ b/spec/classes/core/docker_spec.rb
@@ -11,7 +11,7 @@ describe 'profile::core::docker' do
     is_expected.to contain_class('docker').with(
       overlay2_override_kernel_check: true,
       socket_group: 70_014,
-      socket_override: true,
+      socket_override: false,
       storage_driver: 'overlay2',
       version: '19.03.15',
     )
@@ -20,6 +20,17 @@ describe 'profile::core::docker' do
   it { is_expected.to contain_class('yum::plugin::versionlock') }
   it { is_expected.to have_yum__versionlock_resource_count(2) }
   it { is_expected.to contain_class('docker::networks') }
+
+  it do
+    is_expected.to contain_systemd__dropin_file('wait-for-docker-group.conf').with(
+      unit: 'docker.socket',
+      content: %r{SocketGroup=root},
+    )
+  end
+
+  it do
+    is_expected.to contain_file('/etc/systemd/system/docker.service.d/wait-for-docker-group.conf').with_content(%r{Requires=docker.socket containerd.service sssd.service})
+  end
 
   context 'when site tu' do
     let(:node_params) do


### PR DESCRIPTION
In an attempt to fix the start up dep ordering problem where
`docker.socket` (yes, `docker.socket`, not `docker.server`) attempts to
start up before `sssd` is able to resolve group names from IPA. The fix
is to set docket.socket to use `root` as the group as `dockerd` will
chgrp the socket as startup anyways.  We then add a dep from
`docker.service` on `sssd.service` in an attempt to ensure that it is
possible to resolve the `docker` group via IPA.