### PR TITLE
Bump ccs_software module to 1.0.1

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -133,7 +133,7 @@ mod 'lsst/ccs_sal',
   ref: 'v0.7.1'
 mod 'lsst/ccs_software',
   git: 'https://github.com/lsst-it/puppet-ccs_software.git',
-  ref: 'v1.0.0'
+  ref: 'v1.0.1'
 mod 'lsst/maven',
   git: 'https://github.com/lsst-it/puppet-maven.git',
   ref: 'v1.0.0'


### PR DESCRIPTION
This uses the CCS remote config server.

Ie, it adds to /etc/ccs/ccsGlobal.properties the line org.lsst.ccs.config.remote=true