### PR TITLE
hiera: move auxtel ccs udp_properties to a cluster-wide setting

### DIFF
--- a/hieradata/cluster/auxtel-ccs.yaml
+++ b/hieradata/cluster/auxtel-ccs.yaml
@@ -127,6 +127,11 @@ ccs_software::global_properties:
   - "org.lsst.ccs.subsystem.agent.property.cluster=%{lookup('ccs_instrument')}"
   - "org.lsst.ccs.subsystem.agent.property.site=%{lookup('ccs_site')}"
 
+ccs_software::udp_properties:
+  - "org.lsst.ccs.jgroups.LOG.UDP.mcast_port=26978"
+  - "org.lsst.ccs.jgroups.STATUS.UDP.mcast_port=36978"
+  - "org.lsst.ccs.jgroups.COMMAND.UDP.mcast_port=46978"
+
 ccs_sal::ospl_home: "/opt/OpenSpliceDDS/V6.10.4/HDE/x86_64.linux"
 ccs_sal::rpms:
   ts_sal_utils: "ts_sal_utils-6.1.0-1.x86_64.rpm"

--- a/hieradata/node/auxtel-fp01.cp.lsst.org.yaml
+++ b/hieradata/node/auxtel-fp01.cp.lsst.org.yaml
@@ -61,11 +61,6 @@ nfs::client_mounts:
 
 ccs_monit::hwraid: false
 
-ccs_software::udp_properties:
-  - "org.lsst.ccs.jgroups.LOG.UDP.mcast_port=26978"
-  - "org.lsst.ccs.jgroups.STATUS.UDP.mcast_port=36978"
-  - "org.lsst.ccs.jgroups.COMMAND.UDP.mcast_port=46978"
-
 ccs_software::services:
   ## FIXME this should be changed to prod, and a local systemctl override
   ## used to get the dev version.

--- a/hieradata/node/auxtel-mcm.cp.lsst.org.yaml
+++ b/hieradata/node/auxtel-mcm.cp.lsst.org.yaml
@@ -42,11 +42,6 @@ ccs_software::global_properties:
   - "org.hibernate.engine.internal.level=WARNING"
   - ".level=WARNING"
 
-ccs_software::udp_properties:
-  - "org.lsst.ccs.jgroups.LOG.UDP.mcast_port=26978"
-  - "org.lsst.ccs.jgroups.STATUS.UDP.mcast_port=36978"
-  - "org.lsst.ccs.jgroups.COMMAND.UDP.mcast_port=46978"
-
 ccs_software::services:
   prod:
     - "mmm"

--- a/hieradata/role/atshcu.yaml
+++ b/hieradata/role/atshcu.yaml
@@ -29,11 +29,6 @@ nfs::client_mounts:
     server: "auxtel-fp01.cp.lsst.org"
     atboot: true
 
-ccs_software::udp_properties:
-  - "org.lsst.ccs.jgroups.LOG.UDP.mcast_port=26978"
-  - "org.lsst.ccs.jgroups.STATUS.UDP.mcast_port=36978"
-  - "org.lsst.ccs.jgroups.COMMAND.UDP.mcast_port=46978"
-
 ccs_software::services:
   ## FIXME this should be changed to prod, and a local systemctl override
   ## used to get the dev version.


### PR DESCRIPTION
The net effect is to add these missing settings to node auxtel-dc01.

I see auxtel nodes are currently on a non-standard branch, so either these changes need to eventually be applied to that branch, or the auxtel branch needs to be merged into production (if appropriate).