### PR TITLE
(profile::core::common) rm ifcfg- file

### DIFF
--- a/site/profile/manifests/core/common.pp
+++ b/site/profile/manifests/core/common.pp
@@ -172,4 +172,11 @@ class profile::core::common (
       ensure => running,
       enable => true,
   })
+
+  # foreman provisioning templates created a `ifcfg-` on many hosts.  This seemed harmless but
+  # it has been discovered that this causes libvirt report a change interfaces with no name
+  # when enumerating the physical interfaces via the api.
+  file { '/etc/sysconfig/network-scripts/ifcfg-':
+    ensure => absent,
+  }
 }

--- a/spec/classes/core/common_spec.rb
+++ b/spec/classes/core/common_spec.rb
@@ -19,4 +19,8 @@ describe 'profile::core::common' do
   it do
     is_expected.to contain_service('NetworkManager').with(ensure: 'running', enable: true)
   end
+
+  it do
+    is_expected.to contain_file('/etc/sysconfig/network-scripts/ifcfg-').with_ensure('absent')
+  end
 end


### PR DESCRIPTION
Remove the ifcfg- file created on some hosts by problems with the
foreman provisioning template.

The presence of `/etc/sysconfig/network-scripts/ifcfg-` file on hosts running `libvirt` was causing strange errors via the API. Removing this fix fixed the errors.