### PR TITLE
(profile::core::puppet_master) fix cron /dev/null redirects

### DIFF
--- a/site/profile/manifests/core/puppet_master.pp
+++ b/site/profile/manifests/core/puppet_master.pp
@@ -48,7 +48,7 @@ class profile::core::puppet_master (
   # Using cron seems slightly more obvious than creating a timer unit than triggers a one shot
   # service to restart the original service unit.
   cron { 'webhook':
-    command => '/usr/bin/systemctl restart webhook /dev/null 2>&1',
+    command => '/usr/bin/systemctl restart webhook > /dev/null 2>&1',
     user    => 'root',
     hour    => 4,
     minute  => 42,
@@ -101,7 +101,7 @@ class profile::core::puppet_master (
   }
 
   cron { 'smee':
-    command => '/usr/bin/systemctl restart smee /dev/null 2>&1',
+    command => '/usr/bin/systemctl restart smee > /dev/null 2>&1',
     user    => 'root',
     hour    => 4,
     minute  => 42,

--- a/spec/classes/core/puppet_master_spec.rb
+++ b/spec/classes/core/puppet_master_spec.rb
@@ -6,4 +6,12 @@ describe 'profile::core::puppet_master' do
   it { is_expected.to compile.with_all_deps }
   it { is_expected.to contain_cron('webhook') }
   it { is_expected.to contain_cron('smee') }
+
+  it do
+    is_expected.to contain_cron('webhook').with_command('/usr/bin/systemctl restart webhook > /dev/null 2>&1')
+  end
+
+  it do
+    is_expected.to contain_cron('smee').with_command('/usr/bin/systemctl restart smee > /dev/null 2>&1')
+  end
 end


### PR DESCRIPTION
A typo (missing >) is causing error emails to pile up in
/var/spool/mail/root.