### PR TITLE
(profile::core::debugutils) add jq package

### DIFF
--- a/hieradata/role/rke.yaml
+++ b/hieradata/role/rke.yaml
@@ -16,7 +16,6 @@ packages:
   - "bash-completion-extras"
   - "gdisk"
   - "git"
-  - "jq"
   - "kubectl"
   - "vim"
 sysctl::values::args:

--- a/site/profile/data/common.yaml
+++ b/site/profile/data/common.yaml
@@ -6,6 +6,7 @@ profile::core::debugutils::packages:
   - "iftop"
   - "iperf"
   - "iperf3"
+  - "jq"
   - "lsof"
   - "mtr"
   - "net-tools"

--- a/spec/classes/core/debugutils_spec.rb
+++ b/spec/classes/core/debugutils_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'profile::core::debugutils' do
+  it { is_expected.to compile.with_all_deps }
+
+  include_examples 'debugutils'
+end

--- a/spec/hosts/roles/foreman_spec.rb
+++ b/spec/hosts/roles/foreman_spec.rb
@@ -21,6 +21,8 @@ describe 'test1.dev.lsst.org', :site do
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_class('profile::core::puppet_master') }
 
+        include_examples 'debugutils'
+
         it do
           is_expected.to contain_class('foreman').with(
             version: FOREMAN_VERSION,

--- a/spec/hosts/roles/rke_spec.rb
+++ b/spec/hosts/roles/rke_spec.rb
@@ -16,6 +16,8 @@ describe 'test1.dev.lsst.org', :site do
 
         it { is_expected.to compile.with_all_deps }
 
+        include_examples 'debugutils'
+
         it { is_expected.to contain_class('profile::core::rke') }
       end
     end # site
@@ -31,6 +33,8 @@ describe 'test1.dev.lsst.org', :site do
       end
 
       it { is_expected.to compile.with_all_deps }
+
+      include_examples 'debugutils'
 
       it { is_expected.to contain_class('profile::core::rke') }
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -243,4 +243,8 @@ shared_examples 'daq common' do
   end
 end
 
+shared_examples 'debugutils' do
+  it { is_expected.to contain_package('jq') }
+end
+
 # 'spec_overrides' from sync.yml will appear below this line


### PR DESCRIPTION
Migrate jq package into profile::core::debugutils from the rke role to make it more widely available.