### PR TITLE
hiera: no longer set ccs_monit::temp for comcam-fp01

### DIFF
--- a/hieradata/node/comcam-fp01.cp.lsst.org.yaml
+++ b/hieradata/node/comcam-fp01.cp.lsst.org.yaml
@@ -52,7 +52,6 @@ nfs::client_mounts:
     server: "%{facts.fqdn}"
     atboot: true
 
-ccs_monit::temp: true
 ccs_monit::ping_hosts:
   - "comcam-db01"
   - "comcam-dc01"


### PR DESCRIPTION
It just causes warnings.
Ref https://jira.lsstcorp.org/browse/IT-3814