### PR TITLE
fix ipa client setup order of operations

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -41,7 +41,7 @@ mod 'puppet/chrony', '2.3.0'
 mod 'puppet/cron', '3.0.0'
 mod 'puppet/epel', '4.1.0'
 mod 'puppet/extlib', '6.0.0'
-mod 'puppetfinland/easy_ipa', git: 'https://github.com/lsst-it/puppet-ipa', ref: 'production'  # https://github.com/Puppet-Finland/puppet-ipa/pull/32
+mod 'puppetfinland/easy_ipa', git: 'https://github.com/lsst-it/puppet-ipa', ref: 'lsst-2.3.0'  # https://github.com/Puppet-Finland/puppet-ipa/pull/32
 mod 'puppet/ipset', '2.1.0'
 mod 'puppetlabs/accounts', '7.1.1'
 mod 'puppetlabs/apache', '7.0.0'

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -326,14 +326,14 @@ telegraf::quiet: true
 mit_krb5::includedir:
   - "/etc/krb5.conf.d/"
   - "/var/lib/sss/pubconf/krb5.include.d/"
-mit_krb5::default_realm: "LSST.CLOUD"
-mit_krb5::dns_lookup_realm: false
-mit_krb5::dns_lookup_kdc: false
-mit_krb5::rdns: false
-mit_krb5::dns_canonicalize_hostname: true
-mit_krb5::ticket_lifetime: "24h"
-mit_krb5::forwardable: true
 mit_krb5::default_ccache_name: "FILE:/tmp/krb5cc_%{literal('%')}{uid}"
+mit_krb5::default_realm: "LSST.CLOUD"
+mit_krb5::dns_canonicalize_hostname: true
+mit_krb5::dns_lookup_kdc: false
+mit_krb5::dns_lookup_realm: false
+mit_krb5::forwardable: true
+mit_krb5::rdns: false
+mit_krb5::ticket_lifetime: "24h"
 mit_krb5::realms:
   "%{lookup('mit_krb5::default_realm')}":
     kdc: "%{lookup('easy_ipa::ipa_master_fqdn')}:88"

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -334,6 +334,7 @@ mit_krb5::dns_lookup_realm: false
 mit_krb5::forwardable: true
 mit_krb5::rdns: false
 mit_krb5::ticket_lifetime: "24h"
+mit_krb5::udp_preference_limit: "0"
 mit_krb5::realms:
   "%{lookup('mit_krb5::default_realm')}":
     kdc: "%{lookup('easy_ipa::ipa_master_fqdn')}:88"

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -333,7 +333,7 @@ mit_krb5::rdns: false
 mit_krb5::dns_canonicalize_hostname: true
 mit_krb5::ticket_lifetime: "24h"
 mit_krb5::forwardable: true
-mit_krb5::default_cache_nname: "KEYRING:persistent:%{literal('%')}{uid}"
+mit_krb5::default_ccache_name: "FILE:/tmp/krb5cc_%{literal('%')}{uid}"
 mit_krb5::realms:
   "%{lookup('mit_krb5::default_realm')}":
     kdc: "%{lookup('easy_ipa::ipa_master_fqdn')}:88"

--- a/hieradata/site/cp/role/hvac.yaml
+++ b/hieradata/site/cp/role/hvac.yaml
@@ -1,7 +1,0 @@
----
-profile::core::common::deploy_icinga_agent: true
-profile::core::common::manage_sssd: true
-profile::core::common::manage_krb5: false
-profile::core::common::manage_ldap: false
-profile::core::common::manage_ipa: true
-profile::core::common::install_telegraf: true

--- a/site/profile/manifests/core/ipa.pp
+++ b/site/profile/manifests/core/ipa.pp
@@ -8,5 +8,10 @@
 class profile::core::ipa (
   Hash $default,
 ) {
-  inifile::create_ini_settings($default, { 'path' => '/etc/ipa/default.conf' })
+  $param_defaults = {
+    'path'  => '/etc/ipa/default.conf',
+    require => Class[easy_ipa],
+  }
+
+  inifile::create_ini_settings($default, $param_defaults)
 }

--- a/spec/classes/archive/commmon_spec.rb
+++ b/spec/classes/archive/commmon_spec.rb
@@ -6,7 +6,6 @@ describe 'profile::archive::common', :archiver do
   let(:node_params) do
     {
       site: 'dev',
-      ipa_force_join: false,  # XXX fix easy_ipa mod
     }
   end
 

--- a/spec/classes/core/common_spec.rb
+++ b/spec/classes/core/common_spec.rb
@@ -6,7 +6,6 @@ describe 'profile::core::common' do
   let(:node_params) do
     {
       site: 'dev',
-      ipa_force_join: false,  # XXX fix easy_ipa mod
     }
   end
 

--- a/spec/classes/core/ipa_spec.rb
+++ b/spec/classes/core/ipa_spec.rb
@@ -26,6 +26,6 @@ describe 'profile::core::ipa' do
       section: 'foo',
       setting: 'bar',
       value: 'baz',
-    )
+    ).that_requires('Class[easy_ipa]')
   end
 end

--- a/spec/classes/core/ipa_spec.rb
+++ b/spec/classes/core/ipa_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'profile::core::ipa' do
+  let(:pre_condition) do
+    <<~PP
+      include easy_ipa
+      include sssd
+    PP
+  end
+  let(:params) do
+    {
+      default: {
+        foo: {
+          bar: 'baz',
+        },
+      },
+    }
+  end
+
+  it { is_expected.to compile.with_all_deps }
+
+  it do
+    is_expected.to contain_ini_setting('/etc/ipa/default.conf [foo] bar').with(
+      section: 'foo',
+      setting: 'bar',
+      value: 'baz',
+    )
+  end
+end

--- a/spec/hosts/roles/amor_spec.rb
+++ b/spec/hosts/roles/amor_spec.rb
@@ -2,10 +2,10 @@
 
 require 'spec_helper'
 
-describe 'test1.dev.lsst.org', :site do
+describe 'test1.dev.lsst.org' do
   describe 'amor role' do
     lsst_sites.each do |site|
-      context "with site #{site}" do
+      context "with site #{site}", :site, :common do
         let(:node_params) do
           {
             site: site,

--- a/spec/hosts/roles/amor_spec.rb
+++ b/spec/hosts/roles/amor_spec.rb
@@ -11,7 +11,6 @@ describe 'test1.dev.lsst.org', :site do
             site: site,
             role: 'amor',
             cluster: 'amor',
-            ipa_force_join: false, # easy_ipa
           }
         end
 

--- a/spec/hosts/roles/atsccs_spec.rb
+++ b/spec/hosts/roles/atsccs_spec.rb
@@ -23,7 +23,7 @@ describe 'atsccs role' do
       )
     end
 
-    describe 'auxtel-mcm.tu.lsst.org', :site do
+    describe 'auxtel-mcm.tu.lsst.org', :site, :common do
       it { is_expected.to compile.with_all_deps }
 
       include_examples 'generic auxtel-mcm'
@@ -37,7 +37,7 @@ describe 'atsccs role' do
       )
     end
 
-    describe 'auxtel-mcm.cp.lsst.org', :site do
+    describe 'auxtel-mcm.cp.lsst.org', :site, :common do
       it { is_expected.to compile.with_all_deps }
 
       include_examples 'generic auxtel-mcm'

--- a/spec/hosts/roles/atsccs_spec.rb
+++ b/spec/hosts/roles/atsccs_spec.rb
@@ -11,7 +11,6 @@ describe 'atsccs role' do
     {
       role: 'atsccs',
       cluster: 'auxtel-ccs',
-      ipa_force_join: false, # easy_ipa
     }
   end
 

--- a/spec/hosts/roles/atsdaq_spec.rb
+++ b/spec/hosts/roles/atsdaq_spec.rb
@@ -13,7 +13,6 @@ describe 'atsdaq role' do
     {
       role: 'atsdaq',
       cluster: 'auxtel-ccs',
-      ipa_force_join: false, # easy_ipa
     }
   end
 

--- a/spec/hosts/roles/atsdaq_spec.rb
+++ b/spec/hosts/roles/atsdaq_spec.rb
@@ -18,7 +18,7 @@ describe 'atsdaq role' do
 
   let(:facts) { { fqdn: self.class.description } }
 
-  describe 'auxtel-fp01.cp.lsst.org', :site do
+  describe 'auxtel-fp01.cp.lsst.org', :site, :common do
     let(:node_params) do
       super().merge(
         site: 'cp',
@@ -30,7 +30,7 @@ describe 'atsdaq role' do
     include_examples 'generic auxtel-fp'
   end # host
 
-  describe 'auxtel-fp01.tu.lsst.org', :site do
+  describe 'auxtel-fp01.tu.lsst.org', :site, :common do
     let(:node_params) do
       super().merge(
         site: 'tu',

--- a/spec/hosts/roles/auxtel_archiver_spec.rb
+++ b/spec/hosts/roles/auxtel_archiver_spec.rb
@@ -10,7 +10,6 @@ describe 'test1.dev.lsst.org', :site do
           {
             site: site,
             role: 'auxtel-archiver',
-            ipa_force_join: false, # easy_ipa
           }
         end
 

--- a/spec/hosts/roles/auxtel_archiver_spec.rb
+++ b/spec/hosts/roles/auxtel_archiver_spec.rb
@@ -2,10 +2,10 @@
 
 require 'spec_helper'
 
-describe 'test1.dev.lsst.org', :site do
+describe 'test1.dev.lsst.org' do
   describe 'auxtel-archiver role' do
     lsst_sites.each do |site|
-      context "with site #{site}" do
+      context "with site #{site}", :site, :common do
         let(:node_params) do
           {
             site: site,

--- a/spec/hosts/roles/ccs_dc_spec.rb
+++ b/spec/hosts/roles/ccs_dc_spec.rb
@@ -16,7 +16,7 @@ describe 'ccs-dc role' do
 
   let(:facts) { { fqdn: self.class.description } }
 
-  describe 'comcam-dc01.cp.lsst.org', :site do
+  describe 'comcam-dc01.cp.lsst.org', :site, :common do
     let(:node_params) do
       super().merge(
         site: 'cp',
@@ -28,7 +28,7 @@ describe 'ccs-dc role' do
     include_examples 'generic ccs-dc'
   end # host
 
-  describe 'comcam-dc01.tu.lsst.org', :site do
+  describe 'comcam-dc01.tu.lsst.org', :site, :common do
     let(:node_params) do
       super().merge(
         site: 'tu',

--- a/spec/hosts/roles/ccs_dc_spec.rb
+++ b/spec/hosts/roles/ccs_dc_spec.rb
@@ -11,7 +11,6 @@ describe 'ccs-dc role' do
     {
       role: 'ccs-dc',
       cluster: 'comcam-ccs',
-      ipa_force_join: false, # easy_ipa
     }
   end
 

--- a/spec/hosts/roles/comcam_archiver_spec.rb
+++ b/spec/hosts/roles/comcam_archiver_spec.rb
@@ -2,10 +2,10 @@
 
 require 'spec_helper'
 
-describe 'test1.dev.lsst.org', :site do
+describe 'test1.dev.lsst.org' do
   describe 'comcam-archiver role' do
     lsst_sites.each do |site|
-      context "with site #{site}" do
+      context "with site #{site}", :site, :common do
         let(:node_params) do
           {
             site: site,

--- a/spec/hosts/roles/comcam_archiver_spec.rb
+++ b/spec/hosts/roles/comcam_archiver_spec.rb
@@ -10,7 +10,6 @@ describe 'test1.dev.lsst.org', :site do
           {
             site: site,
             role: 'comcam-archiver',
-            ipa_force_join: false, # easy_ipa
           }
         end
 

--- a/spec/hosts/roles/comcam_fp_spec.rb
+++ b/spec/hosts/roles/comcam_fp_spec.rb
@@ -20,7 +20,7 @@ describe 'comcam-fp role' do
 
   let(:facts) { { fqdn: self.class.description } }
 
-  describe 'comcam-fp01.cp.lsst.org', :site do
+  describe 'comcam-fp01.cp.lsst.org', :site, :common do
     let(:node_params) do
       super().merge(
         site: 'cp',
@@ -34,7 +34,7 @@ describe 'comcam-fp role' do
     it { is_expected.to contain_class('daq::daqsdk').with_version('R5-V3.2') }
   end # host
 
-  describe 'comcam-fp01.tu.lsst.org', :site do
+  describe 'comcam-fp01.tu.lsst.org', :site, :common do
     let(:node_params) do
       super().merge(
         site: 'tu',

--- a/spec/hosts/roles/comcam_fp_spec.rb
+++ b/spec/hosts/roles/comcam_fp_spec.rb
@@ -15,7 +15,6 @@ describe 'comcam-fp role' do
     {
       role: 'comcam-fp',
       cluster: 'comcam-ccs',
-      ipa_force_join: false, # easy_ipa
     }
   end
 

--- a/spec/hosts/roles/daq_mgt_spec.rb
+++ b/spec/hosts/roles/daq_mgt_spec.rb
@@ -101,7 +101,6 @@ describe 'daq-mgt role' do
   let(:node_params) do
     {
       role: 'daq-mgt',
-      ipa_force_join: false, # easy_ipa
     }
   end
 

--- a/spec/hosts/roles/daq_mgt_spec.rb
+++ b/spec/hosts/roles/daq_mgt_spec.rb
@@ -111,7 +111,7 @@ describe 'daq-mgt role' do
   # fully test features when depend upon host specific data.  An alternative
   # would be to construct an alternate hiera hierarchy for testing each role
   # with synthetic node data.
-  describe 'auxtel-daq-mgt.cp.lsst.org', :site do
+  describe 'auxtel-daq-mgt.cp.lsst.org', :site, :common do
     let(:node_params) do
       super().merge(
         site: 'cp',
@@ -145,7 +145,7 @@ describe 'daq-mgt role' do
     end
   end
 
-  describe 'daq-mgt.tu.lsst.org', :site do
+  describe 'daq-mgt.tu.lsst.org', :site, :common do
     let(:node_params) do
       super().merge(
         site: 'tu',
@@ -179,7 +179,7 @@ describe 'daq-mgt role' do
     end
   end
 
-  describe 'comcam-daq-mgt.cp.lsst.org', :site do
+  describe 'comcam-daq-mgt.cp.lsst.org', :site, :common do
     let(:node_params) do
       super().merge(
         site: 'cp',

--- a/spec/hosts/roles/docker_compose_spec.rb
+++ b/spec/hosts/roles/docker_compose_spec.rb
@@ -11,7 +11,6 @@ describe 'test1.dev.lsst.org', :site do
             site: site,
             role: 'docker-compose',
             cluster: 'azar',
-            ipa_force_join: false, # easy_ipa
           }
         end
 

--- a/spec/hosts/roles/docker_compose_spec.rb
+++ b/spec/hosts/roles/docker_compose_spec.rb
@@ -2,10 +2,10 @@
 
 require 'spec_helper'
 
-describe 'test1.dev.lsst.org', :site do
+describe 'test1.dev.lsst.org' do
   describe 'docker-compose role' do
     lsst_sites.each do |site|
-      context "with site #{site}" do
+      context "with site #{site}", :site, :common do
         let(:node_params) do
           {
             site: site,

--- a/spec/hosts/roles/dtn_spec.rb
+++ b/spec/hosts/roles/dtn_spec.rb
@@ -10,7 +10,6 @@ describe 'test1.dev.lsst.org', :site do
           {
             site: site,
             role: 'dtn',
-            ipa_force_join: false, # easy_ipa
           }
         end
 

--- a/spec/hosts/roles/dtn_spec.rb
+++ b/spec/hosts/roles/dtn_spec.rb
@@ -2,10 +2,10 @@
 
 require 'spec_helper'
 
-describe 'test1.dev.lsst.org', :site do
+describe 'test1.dev.lsst.org' do
   describe 'dtn role' do
     lsst_sites.each do |site|
-      context "with site #{site}" do
+      context "with site #{site}", :site, :common do
         let(:node_params) do
           {
             site: site,

--- a/spec/hosts/roles/foreman_spec.rb
+++ b/spec/hosts/roles/foreman_spec.rb
@@ -14,7 +14,6 @@ describe 'test1.dev.lsst.org', :site do
           {
             site: site,
             role: 'foreman',
-            ipa_force_join: false, # easy_ipa
           }
         end
 

--- a/spec/hosts/roles/foreman_spec.rb
+++ b/spec/hosts/roles/foreman_spec.rb
@@ -6,10 +6,10 @@ FOREMAN_VERSION = '2.4.1'
 PUPPETSERVER_VERSION = '6.19.0'
 TERMINI_VERSION = '6.19.1'
 
-describe 'test1.dev.lsst.org', :site do
+describe 'test1.dev.lsst.org' do
   describe 'foreman role' do
     lsst_sites.each do |site|
-      context "with site #{site}" do
+      context "with site #{site}", :site, :common do
         let(:node_params) do
           {
             site: site,

--- a/spec/hosts/roles/forwarder_spec.rb
+++ b/spec/hosts/roles/forwarder_spec.rb
@@ -10,7 +10,6 @@ describe 'forwarder role' do
           site: site,
           role: 'forwarder',
           cluster: 'comcam-archive',
-          ipa_force_join: false, # easy_ipa
         }
       end
 

--- a/spec/hosts/roles/forwarder_spec.rb
+++ b/spec/hosts/roles/forwarder_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 describe 'forwarder role' do
   lsst_sites.each do |site|
-    context "with site #{site}", :site do
+    context "with site #{site}", :site, :common do
       let(:node_params) do
         {
           site: site,

--- a/spec/hosts/roles/generic_spec.rb
+++ b/spec/hosts/roles/generic_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'generic role' do
+  let(:node_params) do
+    {
+      role: 'generic',
+    }
+  end
+
+  let(:facts) { { fqdn: self.class.description } }
+
+  lsst_sites.each do |site|
+    describe "generic.#{site}.lsst.org", :site, :common do
+      let(:node_params) do
+        super().merge(
+          site: site,
+        )
+      end
+
+      it { is_expected.to compile.with_all_deps }
+    end # host
+  end # lsst_sites
+end # role

--- a/spec/hosts/roles/hexrot_spec.rb
+++ b/spec/hosts/roles/hexrot_spec.rb
@@ -13,7 +13,6 @@ describe 'test1.dev.lsst.org', :site do
           {
             site: site,
             role: role,
-            ipa_force_join: false, # easy_ipa
           }
         end
 

--- a/spec/hosts/roles/hexrot_spec.rb
+++ b/spec/hosts/roles/hexrot_spec.rb
@@ -2,13 +2,13 @@
 
 require 'spec_helper'
 
-describe 'test1.dev.lsst.org', :site do
+describe 'test1.dev.lsst.org' do
   role = 'hexrot'
   let(:role) { role }
 
   describe "#{role} role" do
     lsst_sites.each do |site|
-      context "with site #{site}" do
+      context "with site #{site}", :site, :common do
         let(:node_params) do
           {
             site: site,

--- a/spec/hosts/roles/hvac_spec.rb
+++ b/spec/hosts/roles/hvac_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'hvac role' do
+  let(:node_params) do
+    {
+      role: 'hvac',
+    }
+  end
+
+  let(:facts) { { fqdn: self.class.description } }
+
+  lsst_sites.each do |site|
+    describe "hvac.#{site}.lsst.org", :site, :common do
+      let(:node_params) do
+        super().merge(
+          site: site,
+        )
+      end
+
+      it { is_expected.to compile.with_all_deps }
+    end # host
+  end # lsst_sites
+end # role

--- a/spec/hosts/roles/icinga_master_spec.rb
+++ b/spec/hosts/roles/icinga_master_spec.rb
@@ -10,7 +10,6 @@ describe 'test1.dev.lsst.org', :site do
           {
             site: site,
             role: 'icinga-master',
-            ipa_force_join: false, # easy_ipa
           }
         end
 

--- a/spec/hosts/roles/icinga_master_spec.rb
+++ b/spec/hosts/roles/icinga_master_spec.rb
@@ -2,10 +2,10 @@
 
 require 'spec_helper'
 
-describe 'test1.dev.lsst.org', :site do
+describe 'test1.dev.lsst.org' do
   describe 'icinga-master role' do
     lsst_sites.each do |site|
-      context "with site #{site}" do
+      context "with site #{site}", :site, :common do
         let(:node_params) do
           {
             site: site,

--- a/spec/hosts/roles/m2_spec.rb
+++ b/spec/hosts/roles/m2_spec.rb
@@ -2,10 +2,10 @@
 
 require 'spec_helper'
 
-describe 'test1.dev.lsst.org', :site do
+describe 'test1.dev.lsst.org' do
   describe 'm2 role' do
     lsst_sites.each do |site|
-      context "with site #{site}" do
+      context "with site #{site}", :site, :common do
         let(:node_params) do
           {
             site: site,

--- a/spec/hosts/roles/m2_spec.rb
+++ b/spec/hosts/roles/m2_spec.rb
@@ -10,7 +10,6 @@ describe 'test1.dev.lsst.org', :site do
           {
             site: site,
             role: 'm2',
-            ipa_force_join: false, # easy_ipa
           }
         end
 

--- a/spec/hosts/roles/rke_spec.rb
+++ b/spec/hosts/roles/rke_spec.rb
@@ -10,7 +10,6 @@ describe 'test1.dev.lsst.org', :site do
           {
             site: site,
             role: 'rke',
-            ipa_force_join: false, # easy_ipa
           }
         end
 
@@ -34,7 +33,6 @@ describe 'test1.dev.lsst.org', :site do
           site: 'ls',
           role: 'rke',
           cluster: 'antu',
-          ipa_force_join: false, # easy_ipa
         }
       end
 

--- a/spec/hosts/roles/rke_spec.rb
+++ b/spec/hosts/roles/rke_spec.rb
@@ -2,10 +2,10 @@
 
 require 'spec_helper'
 
-describe 'test1.dev.lsst.org', :site do
+describe 'test1.dev.lsst.org' do
   describe 'rke role' do
     lsst_sites.each do |site|
-      context "with site #{site}" do
+      context "with site #{site}", :site, :common do
         let(:node_params) do
           {
             site: site,
@@ -27,7 +27,7 @@ describe 'test1.dev.lsst.org', :site do
       end
     end # site
 
-    context 'with antu cluster', :lhn_node do
+    context 'with antu cluster', :lhn_node, :site, :common do
       let(:node_params) do
         {
           site: 'ls',

--- a/spec/hosts/roles/ts_csc_spec.rb
+++ b/spec/hosts/roles/ts_csc_spec.rb
@@ -2,10 +2,10 @@
 
 require 'spec_helper'
 
-describe 'test1.dev.lsst.org', :site do
+describe 'test1.dev.lsst.org' do
   describe 'ts-csc role' do
     lsst_sites.each do |site|
-      context "with site #{site}" do
+      context "with site #{site}", :site, :common do
         let(:node_params) do
           {
             site: site,

--- a/spec/hosts/roles/ts_csc_spec.rb
+++ b/spec/hosts/roles/ts_csc_spec.rb
@@ -11,7 +11,6 @@ describe 'test1.dev.lsst.org', :site do
             site: site,
             role: 'ts-csc',
             cluster: 'trewa',
-            ipa_force_join: false, # easy_ipa
           }
         end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -115,12 +115,17 @@ shared_context 'with site.pp', :site do
   after(:context) { RSpec.configuration.manifest = nil }
 end
 
-shared_examples 'common', :common do
+shared_examples 'krb5.conf content' do |match|
   it do
     is_expected.to contain_concat__fragment('mit_krb5::libdefaults').with(
-      content: %r{default_ccache_name = FILE:/tmp/krb5cc_%{uid}},
+      content: match,
     )
   end
+end
+
+shared_examples 'common', :common do
+  include_examples 'krb5.conf content', %r{default_ccache_name = FILE:/tmp/krb5cc_%{uid}}
+  include_examples 'krb5.conf content', %r{udp_preference_limit = 0}
 end
 
 shared_examples 'lhn sysctls', :lhn_node do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -115,6 +115,14 @@ shared_context 'with site.pp', :site do
   after(:context) { RSpec.configuration.manifest = nil }
 end
 
+shared_examples 'common', :common do
+  it do
+    is_expected.to contain_concat__fragment('mit_krb5::libdefaults').with(
+      content: %r{default_ccache_name = FILE:/tmp/krb5cc_%{uid}},
+    )
+  end
+end
+
 shared_examples 'lhn sysctls', :lhn_node do
   it do
     is_expected.to contain_sysctl__value('net.core.rmem_max')


### PR DESCRIPTION
The first puppet agent run on a newly provisioned hosts was failing due to auth configuration related resources attempting to sync prior to the `ipa-client-install` script having been run.