### PR TITLE
decouple profile mod spec from production hiera data

### DIFF
--- a/site/profile/manifests/core/ipa.pp
+++ b/site/profile/manifests/core/ipa.pp
@@ -6,12 +6,14 @@
 #   Set values in `/etc/ipa/default.conf`.
 #
 class profile::core::ipa (
-  Hash $default,
+  Optional[Hash] $default = undef,
 ) {
   $param_defaults = {
     'path'  => '/etc/ipa/default.conf',
     require => Class[easy_ipa],
   }
 
-  inifile::create_ini_settings($default, $param_defaults)
+  if $default {
+    inifile::create_ini_settings($default, $param_defaults)
+  }
 }

--- a/spec/classes/core/docker_spec.rb
+++ b/spec/classes/core/docker_spec.rb
@@ -11,12 +11,12 @@ describe 'profile::core::docker' do
       socket_group: 70_014,
       socket_override: false,
       storage_driver: 'overlay2',
-      version: '20.10.12',
+      version: '19.03.15',
     )
   end
 
   it { is_expected.to contain_class('yum::plugin::versionlock') }
-  it { is_expected.to have_yum__versionlock_resource_count(5) }
+  it { is_expected.to have_yum__versionlock_resource_count(2) }
   it { is_expected.to contain_class('docker::networks') }
 
   it do

--- a/spec/classes/core/ipa_spec.rb
+++ b/spec/classes/core/ipa_spec.rb
@@ -9,23 +9,28 @@ describe 'profile::core::ipa' do
       include sssd
     PP
   end
-  let(:params) do
-    {
-      default: {
-        foo: {
-          bar: 'baz',
-        },
-      },
-    }
+
+  context 'with no params' do
+    it { is_expected.to compile.with_all_deps }
   end
 
-  it { is_expected.to compile.with_all_deps }
+  context 'with default param' do
+    let(:params) do
+      {
+        default: {
+          foo: {
+            bar: 'baz',
+          },
+        },
+      }
+    end
 
-  it do
-    is_expected.to contain_ini_setting('/etc/ipa/default.conf [foo] bar').with(
-      section: 'foo',
-      setting: 'bar',
-      value: 'baz',
-    ).that_requires('Class[easy_ipa]')
+    it do
+      is_expected.to contain_ini_setting('/etc/ipa/default.conf [foo] bar').with(
+        section: 'foo',
+        setting: 'bar',
+        value: 'baz',
+      ).that_requires('Class[easy_ipa]')
+    end
   end
 end

--- a/spec/classes/ts/opensplicedds_spec.rb
+++ b/spec/classes/ts/opensplicedds_spec.rb
@@ -9,7 +9,7 @@ describe 'profile::ts::opensplicedds' do
 
     it do
       is_expected.to contain_package('OpenSpliceDDS')
-        .with_ensure('6.10.4-6.el7')
+        .with_ensure('present')
         .that_requires('Yumrepo[lsst-ts-private]')
     end
   end

--- a/spec/fixtures/hiera-profile-mod.yaml
+++ b/spec/fixtures/hiera-profile-mod.yaml
@@ -1,0 +1,10 @@
+---
+version: 5
+defaults:
+  data_hash: "yaml_data"
+hierarchy:
+  - name: "private hiera"
+    datadir: "./hieradata"
+    paths:
+      - "profile-only.yaml"
+      - "common.yaml"

--- a/spec/fixtures/hieradata/profile-only.yaml
+++ b/spec/fixtures/hieradata/profile-only.yaml
@@ -1,0 +1,15 @@
+---
+# These values are *only* to be used for testing the *profile* module. When
+# testing the profile module, we want to intentionally exclude the production
+# hiera hierarchy. However, due to recursive class inclusion by profile classes,
+# a number of modules are pulled in which have mandatory parameters which
+# would otherwise have to be declared in most spec files.
+easy_ipa::domain: "example.org"
+easy_ipa::ipa_role: "client"
+easy_ipa::ipa_master_fqdn: "foo.example.org"
+easy_ipa::install_sssd: false
+
+resolv_conf::nameservers:
+  - "1.1.1.1"
+
+mit_krb5::default_realm: "example.org"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -82,8 +82,7 @@ end
 RSpec.configure do |c|
   c.default_facts = default_facts
   c.module_path = "#{File.join(root_path, 'site')}:#{File.join(fixtures_path, 'modules')}"
-  # c.manifest = File.join(root_path, 'manifests', 'site.pp')
-  c.hiera_config = File.join(fixtures_path, 'hiera.yaml')
+  c.hiera_config = File.join(fixtures_path, 'hiera-profile-mod.yaml')
   c.before :each do
     # set to strictest setting for testing
     # by default Puppet runs at warning level
@@ -110,7 +109,10 @@ def node_files
 end
 
 shared_context 'with site.pp', :site do
-  before(:context) { RSpec.configuration.manifest = File.join(root_path, 'manifests', 'site.pp') }
+  before(:context) do
+    RSpec.configuration.manifest = File.join(root_path, 'manifests', 'site.pp')
+    RSpec.configuration.hiera_config = File.join(fixtures_path, 'hiera.yaml')
+  end
 
   after(:context) { RSpec.configuration.manifest = nil }
 end


### PR DESCRIPTION
Unit tests of profile classes were, in some cases surprisingly, being effected by production hiera hierarchy data.  This is fixed by using a more limited fixtured hiera configuration by default and while the previous default fixtured hiera configuration is used only for example groups labeled with `:site`, Currently, only host/role specs are using `:site`.