### PR TITLE
Bump ccs java_artisanal version to 2.2.1

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -31,7 +31,7 @@ mod 'lsst/cni', '2.1.0'
 mod 'lsst/daq', '1.0.0'
 mod 'lsst/dellperc', '1.0.1'
 mod 'lsst/helm_binary', '1.0.0'
-mod 'lsst/java_artisanal', '2.1.0'
+mod 'lsst/java_artisanal', '2.2.1'
 mod 'lsst/maven', '2.0.1'
 mod 'lsst/rke', '1.0.0'
 mod 'lsst/tuned', git: 'https://github.com/lsst-it/puppet-tuned', branch: 'production'  # https://github.com/CERIT-SC/puppet-tuned/pull/21


### PR DESCRIPTION
This uses an explicit alternative for the java commands,
rather than relying on priority (which can be fragile).