### PR TITLE
Install newer maven on CCS hosts

### DIFF
--- a/site/profile/manifests/ccs/common.pp
+++ b/site/profile/manifests/ccs/common.pp
@@ -31,6 +31,7 @@ class profile::ccs::common (
   include ccs_software
   include java_artisanal
   include java_artisanal::java17
+  include maven
 
   Class['java_artisanal']
   -> Class['ccs_software']


### PR DESCRIPTION
This installs maven 3.6.3 in /opt and makes it the default.