### PR TITLE
(common) fix setting of yum::plugin::versionlock::clean param

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -287,9 +287,7 @@ rsyslog::config::actions:
     config:
       file: "-/var/log/boot.log"
 
-yum::plugin::versionlock:
-  # trigger `yum clean all`
-  clean: true
+yum::plugin::versionlock::clean: true  # trigger `yum clean all`
 
 letsencrypt::email: "rubinobs-it-las@lsst.org"
 profile::icinga::agent::host_template: "GeneralHostTemplate"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -134,6 +134,8 @@ shared_examples 'common', :common do |opts = {}|
     include_examples 'krb5.conf content', %r{default_ccache_name = FILE:/tmp/krb5cc_%{uid}}
     include_examples 'krb5.conf content', %r{udp_preference_limit = 0}
   end
+
+  it { is_expected.to contain_class('yum::plugin::versionlock').with_clean(true) }
 end
 
 shared_examples 'lhn sysctls', :lhn_node do


### PR DESCRIPTION
The current syntax is nonsense.  There is no `versionlock` param on the
`yum::plugin` class to pass a hash into.

based on:
-#610