### PR TITLE
(Puppetfile) bump saz/timezone to 6.2.0

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -96,7 +96,7 @@ mod 'richardc/datacat', '0.6.2'
 mod 'saz/resolv_conf', '5.0.0'
 mod 'saz/ssh', git: 'https://github.com/lsst-it/saz-puppet-ssh', ref: '7f1a892'  # ssh::client::match_block
 mod 'saz/sudo', '7.0.2'
-mod 'saz/timezone', git: 'https://github.com/saz/puppet-timezone', ref: '6f1a8e1'  # stdlib https://github.com/saz/puppet-timezone/pull/103
+mod 'saz/timezone', '6.2.0'
 mod 'simp/dconf', '0.2.0'
 mod 'simp/gnome', '9.1.0'
 mod 'simp/mate', '1.2.0'


### PR DESCRIPTION
No change in functionality. This is migrating from a git tag to an official release.