### PR TITLE
(Puppetfile) bump lsst/dellperc to 1.1.0

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -28,7 +28,7 @@ mod 'lsst/ccs_sal', git: 'https://github.com/lsst-it/puppet-ccs_sal', ref: 'v1.0
 mod 'lsst/ccs_software', git: 'https://github.com/lsst-it/puppet-ccs_software', ref: 'v1.0.2'
 mod 'lsst/cni', '2.1.0'
 mod 'lsst/daq', '1.0.0'
-mod 'lsst/dellperc', '1.0.1'
+mod 'lsst/dellperc', '1.1.0'
 mod 'lsst/helm_binary', '1.0.0'
 mod 'lsst/java_artisanal', '2.2.1'
 mod 'lsst/maven', '2.0.1'


### PR DESCRIPTION
To pickup EL8 support.