### PR TITLE
Add FQDN entry to /etc/hosts on CCS clusters

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -10,7 +10,6 @@ mod 'derdanne/nfs', '2.1.8'
 mod 'duritong/sysctl', git: 'https://github.com/duritong/puppet-sysctl', ref: '847ec1c'  # migrate to herculesteam/augeasproviders_sysctl; https://github.com/duritong/puppet-sysctl/pull/48
 mod 'example42/network', git: 'https://github.com/lsst-it/puppet-network', ref: 'v3.6.1'  # unmaintained. Migrate to puppet/network?
 mod 'fervid/snapd', '1.2.1' # 2021-05-31 hreinking: snapd for EAS Raspberry Pi
-mod 'ghoneycutt/hosts', git: 'https://github.com/ghoneycutt/puppet-module-hosts', ref: '32315d8'  # https://github.com/ghoneycutt/puppet-module-hosts/pull/86
 mod 'herculesteam/augeasproviders_core', '3.1.0'
 mod 'herculesteam/augeasproviders_shellvar', '4.1.0'
 mod 'icinga/icinga2', '3.2.2'
@@ -30,6 +29,8 @@ mod 'lsst/cni', '2.2.0'
 mod 'lsst/daq', '1.0.0'
 mod 'lsst/dellperc', '1.1.0'
 mod 'lsst/helm_binary', '1.0.0'
+# Fork of ghoneycutt/hosts that includes https://github.com/ghoneycutt/puppet-module-hosts/pull/63
+mod 'lsst/hosts', git: 'https://github.com/lsst-it/puppet-module-hosts', ref: '528475e'
 mod 'lsst/java_artisanal', '2.2.1'
 mod 'lsst/maven', '2.0.1'
 mod 'lsst/rke', '1.1.0'

--- a/hieradata/cluster/auxtel-ccs.yaml
+++ b/hieradata/cluster/auxtel-ccs.yaml
@@ -150,3 +150,5 @@ ccs_sal::rpms_private:
   OpenSpliceDDS: "OpenSpliceDDS-6.10.4-6.el7.x86_64.rpm"
 
 daq::daqsdk::purge: false
+
+hosts::stored_config: false

--- a/hieradata/cluster/comcam-ccs.yaml
+++ b/hieradata/cluster/comcam-ccs.yaml
@@ -170,3 +170,5 @@ ccs_software::installations:
 
 profile::icinga::agent::host_template: "ComCamHostTemplate"
 daq::daqsdk::purge: false
+
+hosts::stored_config: false

--- a/hieradata/cluster/pathfinder-ccs.yaml
+++ b/hieradata/cluster/pathfinder-ccs.yaml
@@ -100,3 +100,5 @@ ccs_software::installations:
       #      - "pathfinder-prod"
 
 daq::daqsdk::purge: false
+
+hosts::stored_config: false


### PR DESCRIPTION
The FQDN entry should be there by default, but the upstream hosts module has a long-standing bug:
https://github.com/ghoneycutt/puppet-module-hosts/issues/40

This change switches to an lsst-it fork of the module, which adds this pull request:
https://github.com/ghoneycutt/puppet-module-hosts/pull/63

This fixes adding the FQDN entry, if stored_config = false (it is true by default).
It is set false only on CCS clusters (though I can't see why it should not be so everywhere).

Ref: https://jira.lsstcorp.org/browse/IT-3889

Note:
This uses the branch IT-3889/fqdn of lsst-it/puppet-module-hosts.
That probably isn't the right way to do it.
Maybe there should be an "lsst_production" (or somesuch) branch in that repo?