### PR TITLE
(Puppetfile) bump puppetlabs/docker to 4.4.0

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -50,7 +50,7 @@ mod 'puppetlabs/apt', '8.3.0'
 mod 'puppetlabs/augeas_core', '1.2.0'
 mod 'puppetlabs/concat', '7.1.1'
 mod 'puppetlabs/cron_core', '1.1.0'
-mod 'puppetlabs/docker', git: 'https://github.com/puppetlabs/puppetlabs-docker', ref: '9e5ff53'  # https://github.com/puppetlabs/puppetlabs-docker/pull/783
+mod 'puppetlabs/docker', '4.4.0'
 mod 'puppetlabs/facts', '1.4.0'
 mod 'puppetlabs/firewall', '3.4.0'
 mod 'puppetlabs/host_core', '1.1.0'


### PR DESCRIPTION
The 4.4.0 release incorporates https://github.com/puppetlabs/puppetlabs-docker/pull/783.

It also includes a fix for the docker swarm facts generating error
messages in syslog. https://github.com/puppetlabs/puppetlabs-docker/pull/817