### PR TITLE
(metadata.json) drop puppet6 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -17,7 +17,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 6.0.0 < 8.0.0"
+      "version_requirement": ">= 7.0.0 < 8.0.0"
     }
   ]
 }


### PR DESCRIPTION
As we have officially migrated to puppet7.