### PR TITLE
update to modern yum::versionlock api 

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -222,8 +222,10 @@ puppet_agent::collection: "puppet7"
 puppet_agent::config:
   - {section: "agent", setting: "environment", ensure: "absent"}
 profile::core::yum::versionlock:
-  0:puppet-agent-7.18.0-1.el7.x86_64:
+  puppet-agent:
     ensure: "present"
+    version: "7.18.0"
+    release: "1.el7"
     before: "Package[puppet-agent]"
 
 # Rsyslog configuration is based on the default rsyslog.conf shipping with CentOS 7.7
@@ -431,17 +433,29 @@ ccs_monit::pkgurl: "%{lookup('profile::ccs::common::pkgurl')}"
 
 profile::core::docker::version: "20.10.12"
 profile::core::docker::versionlock:
-  0:containerd.io-1.4.12-3.1.el7.x86_64:
+  containerd.io:
     # puppetlabs/docker only specifies a package resource for containerd.io for uninstall
     ensure: "present"
-  0:docker-ce-rootless-extras-20.10.12-3.el7.x86_64:
+    version: "1.4.12"
+    release: "3.1.el7"
+  docker-ce:
     ensure: "present"
-  0:docker-scan-plugin-0.12.0-3.el7.x86_64:
-    ensure: "present"
-  1:docker-ce-cli-20.10.12-3.el7.x86_64:
-    ensure: "present"
-    before: "Package[docker-ce-cli]"
-  3:docker-ce-20.10.12-3.el7.x86_64:
-    ensure: "present"
+    epoch: 3
+    version: "%{lookup('profile::core::docker::version')}"
+    release: &docker_release "3.el7"
     # the puppet package resource name is `docker` with a seperate name param of `docker-ce`
     before: "Package[docker]"
+  docker-ce-cli:
+    ensure: "present"
+    epoch: 1
+    version: "%{lookup('profile::core::docker::version')}"
+    release: *docker_release
+    before: "Package[docker-ce-cli]"
+  docker-ce-rootless-extras:
+    ensure: "present"
+    version: "%{lookup('profile::core::docker::version')}"
+    release: *docker_release
+  docker-scan-plugin:
+    ensure: "present"
+    version: "0.12.0"
+    release: *docker_release

--- a/hieradata/role/foreman.yaml
+++ b/hieradata/role/foreman.yaml
@@ -187,32 +187,57 @@ puppet::server_version: *server_version  # XXX does this do anything?
 puppet::version: "%{lookup('puppet_agent::package_version')}"  # agent version
 puppetdb::globals::version: "7.11.0"
 profile::core::yum::versionlock:
-  0:puppetserver-7.9.0-1.el7.noarch:
+  puppetserver:
     ensure: "present"
+    version: "7.9.0"
+    release: "1.el7"
     before: "Package[puppetserver]"
-  0:puppetdb-termini-7.11.0-1.el7.noarch:
+  puppetdb-termini:
     ensure: "present"
+    version: "7.11.0"
+    release: "1.el7"
     before: "Package[puppetdb-termini]"
-  0:foreman-3.2.1-1.el7.noarch:
+  foreman:
     ensure: "present"
-  0:foreman-libvirt-3.2.1-1.el7.noarch:
+    version: "%{lookup('foreman::version')}"
+    release: "1.el7"
+  foreman-libvirt:
     ensure: "present"
-  0:foreman-dynflow-sidekiq-3.2.1-1.el7.noarch:
+    version: "%{lookup('foreman::version')}"
+    release: "1.el7"
+  foreman-dynflow-sidekiq:
     ensure: "present"
-  0:foreman-service-3.2.1-1.el7.noarch:
+    version: "%{lookup('foreman::version')}"
+    release: "1.el7"
+  foreman-service:
     ensure: "present"
-  0:foreman-postgresql-3.2.1-1.el7.noarch:
+    version: "%{lookup('foreman::version')}"
+    release: "1.el7"
+  foreman-postgresql:
     ensure: "present"
-  0:foreman-debug-3.2.1-1.el7.noarch:
+    version: "%{lookup('foreman::version')}"
+    release: "1.el7"
+  foreman-debug:
     ensure: "present"
-  0:foreman-cli-3.2.1-1.el7.noarch:
+    version: "%{lookup('foreman::version')}"
+    release: "1.el7"
+  foreman-cli:
     ensure: "present"
-  1:foreman-installer-3.2.1-1.el7.noarch:
+    version: "%{lookup('foreman::version')}"
+    release: "1.el7"
+  foreman-installer:
     ensure: "present"
-  0:foreman-proxy-3.2.1-1.el7.noarch:
+    epoch: 1
+    version: "%{lookup('foreman::version')}"
+    release: "2.el7"
+  foreman-proxy:
     ensure: "present"
-  0:foreman-vmware-3.2.1-1.el7.noarch:
+    version: "%{lookup('foreman::version')}"
+    release: "1.el7"
+  foreman-vmware:
     ensure: "present"
+    version: "%{lookup('foreman::version')}"
+    release: "1.el7"
 
 redis::globals::scl: "rh-redis5"
 

--- a/hieradata/role/ipareplica.yaml
+++ b/hieradata/role/ipareplica.yaml
@@ -40,21 +40,23 @@ clustershell::groupmembers:
       - "ipa1.dev.lsst.org"
 
 profile::core::yum::versionlock:
-  0:python2-ipaserver-4.6.8-5.el7.centos.6.noarch:
+  python2-ipaserver: &ipa_version
     ensure: "present"
-  0:ipa-client-common-4.6.8-5.el7.centos.6.noarch:
-    ensure: "present"
-  0:python2-ipaclient-4.6.8-5.el7.centos.6.noarch:
-    ensure: "present"
-  0:ipa-server-common-4.6.8-5.el7.centos.6.noarch:
-    ensure: "present"
-  0:ipa-common-4.6.8-5.el7.centos.6.noarch:
-    ensure: "present"
-  0:python2-ipalib-4.6.8-5.el7.centos.6.noarch:
-    ensure: "present"
-  0:ipa-client-4.6.8-5.el7.centos.6.x86_64:
-    ensure: "present"
-  0:ipa-server-4.6.8-5.el7.centos.6.x86_64:
-    ensure: "present"
+    version: "4.6.8"
+    release: "5.el7.centos.6"
+  ipa-client-common:
+    <<: *ipa_version
+  python2-ipaclient:
+    <<: *ipa_version
+  ipa-server-common:
+    <<: *ipa_version
+  ipa-common:
+    <<: *ipa_version
+  python2-ipalib:
+    <<: *ipa_version
+  ipa-client:
+    <<: *ipa_version
+  ipa-server:
+    <<: *ipa_version
 
 profile::core::ipa_pwd_reset::ldap_user: "ldap-passwd-reset"

--- a/hieradata/role/perfsonar.yaml
+++ b/hieradata/role/perfsonar.yaml
@@ -72,5 +72,7 @@ perfsonar::lsregistrationdaemon_ensure: "stopped"
 perfsonar::lsregistrationdaemon_enable: false
 profile::core::yum::versionlock:
   # XXX do we need to versionlock all of the sub-packages as well?
-  0:perfsonar-toolkit-4.4.0-1.el7.noarch:
+  perfsonar-toolkit:
     ensure: "present"
+    version: "4.4.0"
+    release: "1.el7"

--- a/hieradata/role/puppetdb.yaml
+++ b/hieradata/role/puppetdb.yaml
@@ -16,9 +16,10 @@ postgresql::globals::server_package_name: "rh-postgresql12-postgresql-server-sys
 postgresql::globals::service_name: "postgresql"
 postgresql::globals::version: "12"
 profile::core::yum::versionlock:
-  0:puppetdb-7.11.0-1.el7.noarch:
+  puppetdb:
     ensure: "present"
-    before: "Package[puppetdb]"
+    version: "%{lookup('puppetdb::globals::version')}"
+    release: "1.el7"
 puppetdb::database_listen_address: "localhost"
 puppetdb::globals::version: "7.11.0"
 puppetdb::java_args:

--- a/site/profile/data/common.yaml
+++ b/site/profile/data/common.yaml
@@ -139,13 +139,19 @@ profile::core::yum::lsst_ts_private::repos:
 
 profile::core::docker::version: "19.03.15"
 profile::core::docker::versionlock:
-  1:docker-ce-cli-19.03.15-3.el7.x86_64:
+  docker-ce:
     ensure: "present"
-    before: "Package[docker-ce-cli]"
-  3:docker-ce-19.03.15-3.el7.x86_64:
-    ensure: "present"
+    epoch: 3
+    version: "%{lookup('profile::core::docker::version')}"
+    release: &docker_release "3.el7"
     # the puppet package resource name is `docker` with a seperate name param of `docker-ce`
     before: "Package[docker]"
+  docker-ce-cli:
+    ensure: "present"
+    epoch: 1
+    version: "%{lookup('profile::core::docker::version')}"
+    release: *docker_release
+    before: "Package[docker-ce-cli]"
 
 profile::core::sysctl::lhn::sysctls:
   # lhn tuning

--- a/site/profile/manifests/core/kernel.pp
+++ b/site/profile/manifests/core/kernel.pp
@@ -18,55 +18,48 @@ class profile::core::kernel (
   include yum::plugin::versionlock
 
   if $version {
-    $k      = "kernel-${version}"
-    $kt     = "kernel-tools-${version}"
-    $ktlibs = "kernel-tools-libs-${version}"
-    $kdevel = "kernel-devel-${version}"
-    $kdebug = "kernel-debuginfo-${version}"
-
     yum::versionlock { [
-        "0:${k}",
-        "0:${kt}",
-        "0:${ktlibs}",
+        'kernel',
+        'kernel-tools',
+        'kernel-tools-libs',
       ]:
-        ensure => present,
+        ensure  => present,
+        version => $version,
     }
 
     if $devel {
-      $kdevel_vl = "0:${kdevel}"
-
-      yum::versionlock { $kdevel_vl:
-        ensure => present,
+      yum::versionlock { 'kernel-devel':
+        ensure  => present,
+        version => $version,
       }
 
       # reboot is not needed for -devel
       package { 'kernel-devel':
         ensure  => present,
-        name    => $kdevel,
-        require => Yum::Versionlock[$kdevel_vl],
+        name    => "kernel-devel-${version}",
+        require => Yum::Versionlock['kernel-devel'],
       }
     }
 
     if $debuginfo {
-      $kdebug_vl = "0:${kdebug}"
-
-      yum::versionlock { $kdebug_vl:
-        ensure => present,
+      yum::versionlock { 'kernel-debuginfo':
+        ensure  => present,
+        version => $version,
       }
 
       # reboot is not needed for -debuginfo
       package { 'kernel-debuginfo':
         ensure          => present,
-        name            => $kdebug,
+        name            => "kernel-debuginfo-${version}",
         install_options => ['--enablerepo', 'base-debuginfo'],
-        require         => Yum::Versionlock[$kdebug_vl],
+        require         => Yum::Versionlock['kernel-debuginfo'],
       }
     }
 
     # reboot if changing the kernel version
     package { 'kernel':
       ensure => present,
-      name   => $k,
+      name   => "kernel-${version}",
       notify => Reboot['kernel version'],
     }
 

--- a/spec/classes/core/kernel_spec.rb
+++ b/spec/classes/core/kernel_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'profile::core::kernel' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) { facts }
+
+      context 'with no params' do
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to have_yum__versionlock_resource_count(0) }
+      end
+
+      context 'with all params' do
+        let(:params) do
+          {
+            version: '1.2.3',
+            devel: true,
+            debuginfo: true,
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+
+        %w[
+          kernel
+          kernel-tools
+          kernel-tools-libs
+          kernel-devel
+          kernel-debuginfo
+        ].each do |pkg|
+          it do
+            is_expected.to contain_yum__versionlock(pkg).with(
+              ensure: 'present',
+              version: '1.2.3',
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/classes/core/yum_spec.rb
+++ b/spec/classes/core/yum_spec.rb
@@ -19,8 +19,11 @@ describe 'profile::core::yum' do
         let(:params) do
           {
             versionlock: {
-              '0:foo-1-1.noarch': {
+              foo: {
                 ensure: 'present',
+                version: '1',
+                epoch: 1,
+                arch: 'noarch',
               },
             },
           }
@@ -30,7 +33,12 @@ describe 'profile::core::yum' do
         it { is_expected.to contain_class('yum::plugin::versionlock') }
 
         it do
-          is_expected.to contain_yum__versionlock('0:foo-1-1.noarch').with_ensure('present')
+          is_expected.to contain_yum__versionlock('foo').with(
+            ensure: 'present',
+            version: '1',
+            epoch: 1,
+            arch: 'noarch',
+          )
         end
       end
     end

--- a/spec/hosts/roles/amor_spec.rb
+++ b/spec/hosts/roles/amor_spec.rb
@@ -26,7 +26,8 @@ describe "#{role} role" do
           let(:site) { site }
 
           it { is_expected.to compile.with_all_deps }
-          it { is_expected.to contain_class('docker::networks') }
+
+          include_examples 'docker'
         end # host
       end # lsst_sites
     end # on os

--- a/spec/hosts/roles/comcam_archiver_spec.rb
+++ b/spec/hosts/roles/comcam_archiver_spec.rb
@@ -28,6 +28,7 @@ describe "#{role} role" do
 
           include_examples 'lhn sysctls'
           include_examples 'archiver'
+          include_examples 'docker'
 
           it { is_expected.to contain_file('/data/repo/LSSTComCam') }
         end # host

--- a/spec/hosts/roles/docker_compose_spec.rb
+++ b/spec/hosts/roles/docker_compose_spec.rb
@@ -17,7 +17,6 @@ describe "#{role} role" do
         {
           role: role,
           site: site,
-          cluster: 'azar',
         }
       end
 
@@ -27,8 +26,7 @@ describe "#{role} role" do
 
           it { is_expected.to compile.with_all_deps }
 
-          it { is_expected.to contain_class('docker') }
-          it { is_expected.to contain_class('docker::networks') }
+          include_examples 'docker'
         end # host
       end # lsst_sites
     end # on os

--- a/spec/hosts/roles/foreman_spec.rb
+++ b/spec/hosts/roles/foreman_spec.rb
@@ -29,21 +29,31 @@ shared_examples 'generic foreman' do
     )
   end
 
-  [
-    "0:foreman-cli-#{FOREMAN_VERSION}-1.el7.noarch",
-    "0:foreman-debug-#{FOREMAN_VERSION}-1.el7.noarch",
-    "0:foreman-dynflow-sidekiq-#{FOREMAN_VERSION}-1.el7.noarch",
-    "0:foreman-#{FOREMAN_VERSION}-1.el7.noarch",
-    "0:foreman-libvirt-#{FOREMAN_VERSION}-1.el7.noarch",
-    "0:foreman-postgresql-#{FOREMAN_VERSION}-1.el7.noarch",
-    "0:foreman-service-#{FOREMAN_VERSION}-1.el7.noarch",
-    "0:puppetdb-termini-#{TERMINI_VERSION}-1.el7.noarch",
-    "0:puppetserver-#{PUPPETSERVER_VERSION}-1.el7.noarch",
-    "1:foreman-installer-#{FOREMAN_VERSION}-1.el7.noarch",
-    "0:foreman-proxy-#{FOREMAN_VERSION}-1.el7.noarch",
-    "0:foreman-vmware-#{FOREMAN_VERSION}-1.el7.noarch",
+  %w[
+    foreman
+    foreman-cli
+    foreman-debug
+    foreman-dynflow-sidekiq
+    foreman-installer
+    foreman-libvirt
+    foreman-postgresql
+    foreman-proxy
+    foreman-service
+    foreman-vmware
   ].each do |pkg|
-    it { is_expected.to contain_yum__versionlock(pkg) }
+    it { is_expected.to contain_yum__versionlock(pkg).with_version(FOREMAN_VERSION) }
+  end
+
+  it do
+    is_expected.to contain_yum__versionlock('puppetserver').with(
+      version: PUPPETSERVER_VERSION,
+    )
+  end
+
+  it do
+    is_expected.to contain_yum__versionlock('puppetdb-termini').with(
+      version: TERMINI_VERSION,
+    )
   end
 
   it do

--- a/spec/hosts/roles/hexrot_spec.rb
+++ b/spec/hosts/roles/hexrot_spec.rb
@@ -26,6 +26,9 @@ describe "#{role} role" do
 
           it { is_expected.to compile.with_all_deps }
 
+          # XXX hexrot uses devicemapper, so the docker example group isn't included
+          it { is_expected.to contain_class('docker') }
+
           %w[
             profile::core::common
             profile::core::debugutils

--- a/spec/hosts/roles/ipareplica_spec.rb
+++ b/spec/hosts/roles/ipareplica_spec.rb
@@ -2,6 +2,9 @@
 
 require 'spec_helper'
 
+IPA_SERVER_VERSION = '4.6.8'
+IPA_SERVER_RELEASE = '5.el7.centos.6'
+
 role = 'ipareplica'
 
 describe "#{role} role" do
@@ -27,6 +30,24 @@ describe "#{role} role" do
           it { is_expected.to compile.with_all_deps }
 
           include_examples 'common', no_auth: true
+
+          %w[
+            python2-ipaserver
+            ipa-client-common
+            python2-ipaclient
+            ipa-server-common
+            ipa-common
+            python2-ipalib
+            ipa-client
+            ipa-server
+          ].each do |pkg|
+            it do
+              is_expected.to contain_yum__versionlock(pkg).with(
+                version: IPA_SERVER_VERSION,
+                release: IPA_SERVER_RELEASE,
+              )
+            end
+          end
         end # host
       end # lsst_sites
     end # on os

--- a/spec/hosts/roles/perfsonar_spec.rb
+++ b/spec/hosts/roles/perfsonar_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-role = 'auxtel-archiver'
+role = 'perfsonar'
 
 describe "#{role} role" do
   on_supported_os.each do |os, facts|
@@ -26,11 +26,11 @@ describe "#{role} role" do
 
           it { is_expected.to compile.with_all_deps }
 
-          include_examples 'lhn sysctls'
-          include_examples 'archiver'
-          include_examples 'docker'
-
-          it { is_expected.to contain_file('/data/repo/LATISS') }
+          it do
+            is_expected.to contain_yum__versionlock('perfsonar-toolkit').with(
+              version: '4.4.0',
+            )
+          end
         end # host
       end # lsst_sites
     end # on os

--- a/spec/hosts/roles/puppetdb_spec.rb
+++ b/spec/hosts/roles/puppetdb_spec.rb
@@ -5,12 +5,7 @@ require 'spec_helper'
 PUPPETDB_VERSION = '7.11.0'
 
 shared_examples 'puppetdb' do
-  [
-    "0:puppetdb-#{PUPPETDB_VERSION}-1.el7.noarch",
-  ].each do |pkg|
-    it { is_expected.to contain_yum__versionlock(pkg) }
-  end
-
+  it { is_expected.to contain_yum__versionlock('puppetdb').with_version(PUPPETDB_VERSION) }
   it { is_expected.to contain_class('puppetdb::globals').with_version(PUPPETDB_VERSION) }
 end
 

--- a/spec/hosts/roles/rke_spec.rb
+++ b/spec/hosts/roles/rke_spec.rb
@@ -4,6 +4,7 @@ require 'spec_helper'
 
 shared_examples 'generic rke' do
   include_examples 'debugutils'
+  include_examples 'docker'
 
   it { is_expected.to contain_class('profile::core::rke') }
 

--- a/spec/hosts/roles/ts_csc_spec.rb
+++ b/spec/hosts/roles/ts_csc_spec.rb
@@ -26,7 +26,8 @@ describe "#{role} role" do
           let(:site) { site }
 
           it { is_expected.to compile.with_all_deps }
-          it { is_expected.to contain_class('docker::networks') }
+
+          include_examples 'docker'
         end # host
       end # lsst_sites
     end # on os

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -140,6 +140,7 @@ shared_examples 'common', :common do |opts = {}|
   end
 
   it { is_expected.to contain_class('yum::plugin::versionlock').with_clean(true) }
+  it { is_expected.to contain_yum__versionlock('puppet-agent').with_version('7.18.0') }
 end
 
 shared_examples 'lhn sysctls', :lhn_node do
@@ -308,6 +309,42 @@ shared_examples 'puppet_master' do
   end
 
   it { is_expected.to contain_package('ipmitool') }
+end
+
+shared_examples 'docker' do
+  docker_version = '20.10.12'
+
+  it do
+    is_expected.to contain_class('docker').with(
+      overlay2_override_kernel_check: true,
+      socket_group: 70_014,
+      socket_override: false,
+      storage_driver: 'overlay2',
+      version: docker_version,
+    )
+  end
+
+  it { is_expected.to contain_class('docker::networks') }
+
+  %w[
+    docker-ce
+    docker-ce-cli
+    docker-ce-rootless-extras
+  ].each do |pkg|
+    it { is_expected.to contain_yum__versionlock(pkg).with_version(docker_version) }
+  end
+
+  it do
+    is_expected.to contain_yum__versionlock('containerd.io').with(
+      version: '1.4.12',
+    )
+  end
+
+  it do
+    is_expected.to contain_yum__versionlock('docker-scan-plugin').with(
+      version: '0.12.0',
+    )
+  end
 end
 
 # 'spec_overrides' from sync.yml will appear below this line


### PR DESCRIPTION
The semantics of the yum versionlock plugin changed between EL7 and EL8.  The `yum::versionlock` defined type added new parameters in order to be compatible with EL8+.  The new parameters are backwards compatible with EL7.