### PR TITLE
docker cleanup/update

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -49,7 +49,7 @@ mod 'puppetlabs/apt', '8.3.0'
 mod 'puppetlabs/augeas_core', '1.2.0'
 mod 'puppetlabs/concat', '7.1.1'
 mod 'puppetlabs/cron_core', '1.1.0'
-mod 'puppetlabs/docker', git: 'https://github.com/puppetlabs/puppetlabs-docker', ref: '9e5ff53'  # https://github.com/puppetlabs/puppetlabs-docker/pull/783
+mod 'puppetlabs/docker', '4.4.0'
 mod 'puppetlabs/facts', '1.4.0'
 mod 'puppetlabs/firewall', '3.4.0'
 mod 'puppetlabs/host_core', '1.1.0'

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -430,32 +430,3 @@ nfs::nfs_v4_idmap_domain: "%{::domain}"
 profile::ccs::common::pkgurl: "https://repo-nexus.lsst.org/nexus/repository/ccs_private"
 ccs_hcu::pkgurl: "%{lookup('profile::ccs::common::pkgurl')}"
 ccs_monit::pkgurl: "%{lookup('profile::ccs::common::pkgurl')}"
-
-profile::core::docker::version: "20.10.12"
-profile::core::docker::versionlock:
-  containerd.io:
-    # puppetlabs/docker only specifies a package resource for containerd.io for uninstall
-    ensure: "present"
-    version: "1.4.12"
-    release: "3.1.el7"
-  docker-ce:
-    ensure: "present"
-    epoch: 3
-    version: "%{lookup('profile::core::docker::version')}"
-    release: &docker_release "3.el7"
-    # the puppet package resource name is `docker` with a seperate name param of `docker-ce`
-    before: "Package[docker]"
-  docker-ce-cli:
-    ensure: "present"
-    epoch: 1
-    version: "%{lookup('profile::core::docker::version')}"
-    release: *docker_release
-    before: "Package[docker-ce-cli]"
-  docker-ce-rootless-extras:
-    ensure: "present"
-    version: "%{lookup('profile::core::docker::version')}"
-    release: *docker_release
-  docker-scan-plugin:
-    ensure: "present"
-    version: "0.12.0"
-    release: *docker_release

--- a/site/profile/data/common.yaml
+++ b/site/profile/data/common.yaml
@@ -137,8 +137,13 @@ profile::core::yum::lsst_ts_private::repos:
     gpgcheck: false
     target: "/etc/yum.repos.d/lsst-ts-private.repo"
 
-profile::core::docker::version: "19.03.15"
+profile::core::docker::version: "20.10.12"
 profile::core::docker::versionlock:
+  containerd.io:
+    # puppetlabs/docker only specifies a package resource for containerd.io for uninstall
+    ensure: "present"
+    version: "1.4.12"
+    release: "3.1.el7"
   docker-ce:
     ensure: "present"
     epoch: 3
@@ -152,6 +157,14 @@ profile::core::docker::versionlock:
     version: "%{lookup('profile::core::docker::version')}"
     release: *docker_release
     before: "Package[docker-ce-cli]"
+  docker-ce-rootless-extras:
+    ensure: "present"
+    version: "%{lookup('profile::core::docker::version')}"
+    release: *docker_release
+  docker-scan-plugin:
+    ensure: "present"
+    version: "0.12.0"
+    release: *docker_release
 
 profile::core::sysctl::lhn::sysctls:
   # lhn tuning

--- a/site/profile/manifests/core/docker.pp
+++ b/site/profile/manifests/core/docker.pp
@@ -23,6 +23,7 @@ class profile::core::docker (
 
   class { 'docker':
     overlay2_override_kernel_check => true,  # needed on el7
+    package_source                 => 'docker-ce',
     socket_group                   => $socket_group,
     socket_override                => false,
     storage_driver                 => $storage_driver,

--- a/site/profile/manifests/core/docker.pp
+++ b/site/profile/manifests/core/docker.pp
@@ -65,6 +65,14 @@ class profile::core::docker (
     # lint:endignore
   }
 
+  # /etc/docker is normally created by dockerd the first time the service is
+  # started.  However, we would like daemon.json to be in place prior to the
+  # first startup.
+  file { '/etc/docker':
+    ensure => directory,
+    mode   => '0755',
+  }
+
   file { '/etc/docker/daemon.json':
     ensure  => file,
     mode    => '0644',

--- a/site/profile/manifests/core/docker.pp
+++ b/site/profile/manifests/core/docker.pp
@@ -35,8 +35,10 @@ class profile::core::docker (
     ensure_resources('yum::versionlock', $versionlock)
   }
 
-  # allow docker.socket activitation to proceed before sssd is running and the `docker` group
-  # can be resolved via IPA.  It is fine to allow the socket be created with a group of `root`  # as dockerd will chgrp the socket to the correct group when it starts up.
+  # allow docker.socket activitation to proceed before sssd is running and the
+  # `docker` group can be resolved via IPA.  It is fine to allow the socket be
+  # created with a group of `root`  # as dockerd will chgrp the socket to the
+  # correct group when it starts up.
   systemd::dropin_file { 'wait-for-docker-group.conf':
     unit    => 'docker.socket',
     # lint:ignore:strict_indent

--- a/spec/classes/core/docker_spec.rb
+++ b/spec/classes/core/docker_spec.rb
@@ -9,19 +9,7 @@ describe 'profile::core::docker' do
 
       it { is_expected.to compile.with_all_deps }
 
-      it do
-        is_expected.to contain_class('docker').with(
-          overlay2_override_kernel_check: true,
-          socket_group: 70_014,
-          socket_override: false,
-          storage_driver: 'overlay2',
-          version: '19.03.15',
-        )
-      end
-
-      it { is_expected.to contain_class('yum::plugin::versionlock') }
-      it { is_expected.to have_yum__versionlock_resource_count(2) }
-      it { is_expected.to contain_class('docker::networks') }
+      include_examples 'docker'
 
       it do
         is_expected.to contain_systemd__dropin_file('wait-for-docker-group.conf').with(

--- a/spec/classes/core/docker_spec.rb
+++ b/spec/classes/core/docker_spec.rb
@@ -35,7 +35,18 @@ describe 'profile::core::docker' do
       end
 
       it do
-        is_expected.to contain_file('/etc/docker/daemon.json').with_content(%r{"live-restore": true})
+        is_expected.to contain_file('/etc/docker').with(
+          ensure: 'directory',
+          mode: '0755',
+        ).that_comes_before('File[/etc/docker/daemon.json]')
+      end
+
+      it do
+        is_expected.to contain_file('/etc/docker/daemon.json').with(
+          ensure: 'file',
+          mode: '0644',
+          content: %r{"live-restore": true},
+        ).that_notifies('Service[docker]')
       end
     end
   end

--- a/spec/hosts/roles/foreman_spec.rb
+++ b/spec/hosts/roles/foreman_spec.rb
@@ -9,6 +9,7 @@ TERMINI_VERSION = '7.11.0'
 shared_examples 'generic foreman' do
   include_examples 'debugutils'
   include_examples 'puppet_master'
+  include_examples 'docker'
 
   it do
     is_expected.to contain_class('foreman').with(

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -317,6 +317,7 @@ shared_examples 'docker' do
   it do
     is_expected.to contain_class('docker').with(
       overlay2_override_kernel_check: true,
+      package_source: 'docker-ce',
       socket_group: 70_014,
       socket_override: false,
       storage_driver: 'overlay2',


### PR DESCRIPTION
Presently, all roles are using the same docker version.  Removing the hiera keys from the common hierarchy and relying the defaults is both DRYing and removes versionlocks which will have to be updated and maintained for EL8.