### PR TITLE
replace inline kubectl install code with lsst/kubectl mod

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -31,6 +31,7 @@ mod 'lsst/foreman_envsync', '1.0.0'
 mod 'lsst/helm_binary', '1.1.0'
 mod 'lsst/hosts', git: 'https://github.com/lsst-it/puppet-module-hosts', ref: '528475e' # Fork of ghoneycutt/hosts that includes https://github.com/ghoneycutt/puppet-module-hosts/pull/63
 mod 'lsst/java_artisanal', '2.2.2'
+mod 'lsst/kubectl', '0.1.0'
 mod 'lsst/maven', '2.0.2'
 mod 'lsst/rke', '1.2.0'
 mod 'lsst/smee', '1.1.0'

--- a/hieradata/role/rke.yaml
+++ b/hieradata/role/rke.yaml
@@ -1,6 +1,7 @@
 ---
 classes:
   - "clustershell"
+  - "kubectl"
   - "profile::core::common"
   - "profile::core::debugutils"
   - "profile::core::docker"
@@ -16,23 +17,11 @@ packages:
   - "bash-completion-extras"
   - "gdisk"
   - "git"
-  - "kubectl"
   - "vim"
 sysctl::values::args:
   net.bridge.bridge-nf-call-iptables:
     value: 1
     target: "/etc/sysctl.d/80-rke.conf"
-yum::managed_repos:
-  - "kubernetes"
-yum::repos:
-  "kubernetes":
-    ensure: "present"
-    descr: "Kubernetes"
-    enabled: true
-    baseurl: "https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64"
-    gpgcheck: true
-    gpgkey: "https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg"
-    target: "/etc/yum.repos.d/kubernetes.repo"
 profile::core::helm::version: "3.5.4"
 profile::core::kernel::devel: true
 profile::core::kernel::debuginfo: true

--- a/spec/hosts/roles/rke_spec.rb
+++ b/spec/hosts/roles/rke_spec.rb
@@ -6,6 +6,7 @@ shared_examples 'generic rke' do
   include_examples 'debugutils'
   include_examples 'docker'
 
+  it { is_expected.to contain_class('kubectl') }
   it { is_expected.to contain_class('profile::core::rke') }
 
   it do


### PR DESCRIPTION
The existing `kubectl` method uses a Google provided yum repo and rpm to install kubectl.  Google does not provide an equivalent repo for EL8.  Although, the same binary/rpm should work on EL8, it would be ugly to configuring an EL7 yum repo across multiple EL major versions. As a more distribution agnostic approach, the `lsst/kubectl` puppet module downloads and installs official k8s `kubectl` binary releases.