### PR TITLE
add filename extension to icinga-ipl archive

### DIFF
--- a/hieradata/site/dev.yaml
+++ b/hieradata/site/dev.yaml
@@ -1,5 +1,5 @@
 ---
-easy_ipa::ipa_master_fqdn: "ipa1.ls.lsst.org"
+easy_ipa::ipa_master_fqdn: "ipa2.ls.lsst.org"
 # sssd ipa client setup -- do not use on ipa servers
 sssd::domains:
   "lsst.cloud":

--- a/hieradata/site/dev/role/icinga-master.yaml
+++ b/hieradata/site/dev/role/icinga-master.yaml
@@ -1,3 +1,4 @@
 ---
 # p::icinga::master and p::icinga::agent both try to define the `nagios-plugins-all` package
 profile::core::common::deploy_icinga_agent: false
+profile::icinga::master::ldap_server: "ipa1.ls.lsst.org"

--- a/site/profile/manifests/icinga/master.pp
+++ b/site/profile/manifests/icinga/master.pp
@@ -407,7 +407,7 @@ class profile::icinga::master (
   }
 
   ##IcingaWeb IPL
-  archive { '/tmp/icinga-ipl':
+  archive { '/tmp/icinga-ipl.tar.gz':
     ensure       => present,
     extract      => true,
     extract_path => '/tmp',

--- a/site/profile/manifests/icinga/master.pp
+++ b/site/profile/manifests/icinga/master.pp
@@ -418,7 +418,7 @@ class profile::icinga::master (
   }
 
   ##IcingaWeb Incubator
-  archive { '/tmp/icinga-incubator':
+  archive { '/tmp/icinga-incubator.tar.gz':
     ensure       => present,
     extract      => true,
     extract_path => '/tmp',


### PR DESCRIPTION
the file type is been checked by the extension of the file, not the content. 