### PR TITLE
allow ssh between saluser@tel-lt1.tu and saluser@tel-hw1.tu

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -126,3 +126,5 @@ RSpec/ImplicitSubject:
   Enabled: false
 Style/CommentedKeyword:
   Enabled: false
+Naming/FileName:
+  Enabled: false

--- a/hieradata/node/tel-hw1.tu.lsst.org.yaml
+++ b/hieradata/node/tel-hw1.tu.lsst.org.yaml
@@ -29,3 +29,9 @@ network::mroutes_hash:
     routes:
       "140.252.147.16/28": "140.252.147.129"
       "140.252.147.48/28": "140.252.147.129"
+
+profile::core::k5login::k5login:
+  "/home/saluser/.k5login":
+    ensure: "present"
+    principals:
+      - "saluser/tel-lt1.tu.lsst.org@LSST.CLOUD"

--- a/hieradata/node/tel-lt1.tu.lsst.org.yaml
+++ b/hieradata/node/tel-lt1.tu.lsst.org.yaml
@@ -1,0 +1,2 @@
+---
+profile::core::common::manage_resolv_conf: false

--- a/hieradata/node/tel-lt1.tu.lsst.org.yaml
+++ b/hieradata/node/tel-lt1.tu.lsst.org.yaml
@@ -1,2 +1,7 @@
 ---
 profile::core::common::manage_resolv_conf: false
+profile::core::k5login::k5login:
+  "/home/saluser/.k5login":
+    ensure: "present"
+    principals:
+      - "saluser/tel-hw1.tu.lsst.org@LSST.CLOUD"

--- a/site/profile/manifests/ccs/krb5_token.pp
+++ b/site/profile/manifests/ccs/krb5_token.pp
@@ -13,7 +13,7 @@
 class profile::ccs::krb5_token (
   String $user,
   Integer $uid,
-  String $keytab_base64,
+  Sensitive[String[1]] $keytab_base64,
 ) {
   profile::util::keytab { $user:
     uid           => $uid,

--- a/site/profile/manifests/core/common.pp
+++ b/site/profile/manifests/core/common.pp
@@ -78,6 +78,7 @@ class profile::core::common (
   include profile::core::ipa
   include profile::core::k5login
   include profile::core::kernel
+  include profile::core::keytab
   include profile::core::nm_dispatch
   include profile::core::selinux
   include profile::core::systemd

--- a/site/profile/manifests/core/common.pp
+++ b/site/profile/manifests/core/common.pp
@@ -46,6 +46,9 @@
 # @param manage_irqbalance
 #   If `true`, manage irqbalance
 #
+# @param manage_resolv_conf
+#   If `true`, manage resolv.conf
+#
 class profile::core::common (
   Boolean $deploy_icinga_agent = false,
   Boolean $manage_puppet_agent = true,
@@ -61,6 +64,7 @@ class profile::core::common (
   Boolean $manage_scl = true,
   Boolean $manage_repos = true,
   Boolean $manage_irqbalance = true,
+  Boolean $manage_resolv_conf = true,
 ) {
   include accounts
   include augeas
@@ -78,7 +82,6 @@ class profile::core::common (
   include profile::core::selinux
   include profile::core::systemd
   include profile::core::yum
-  include resolv_conf
   include rsyslog
   include rsyslog::config
   include selinux
@@ -159,6 +162,11 @@ class profile::core::common (
       include scl
     }
   }
+
+  if $manage_resolv_conf {
+    include resolv_conf
+  }
+
   class { 'lldpd':
     manage_repo => true,
   }

--- a/site/profile/manifests/core/ipa_pwd_reset.pp
+++ b/site/profile/manifests/core/ipa_pwd_reset.pp
@@ -15,7 +15,7 @@
 #
 
 class profile::core::ipa_pwd_reset (
-  String $keytab_base64,
+  Sensitive[String[1]] $keytab_base64,
   String $secret_key,
   String $ldap_user,
   String $ldap_pwd,
@@ -103,7 +103,7 @@ class profile::core::ipa_pwd_reset (
   #  Create Keytab
   file { "${keytab_path}/${ldap_user}.keytab":
     ensure  => file,
-    content => base64('decode', $keytab_base64),
+    content => base64('decode', $keytab_base64.unwrap),
     mode    => '0600',
     owner   => $ldap_user,
     group   => $ldap_user,

--- a/site/profile/manifests/core/keytab.pp
+++ b/site/profile/manifests/core/keytab.pp
@@ -1,0 +1,17 @@
+# @summary
+#   Generates profile::util::keytab resources
+#
+# @param keytab
+#   Hash of keytab resources to create
+#
+class profile::core::keytab (
+  Optional[Hash[String[1], Hash[String[1], NotUndef]]] $keytab = undef,
+) {
+  if $keytab {
+    $keytab.each | String $name, Hash $conf | {
+      profile::util::keytab { $name:
+        * => $conf,
+      }
+    }
+  }
+}

--- a/site/profile/manifests/core/rke.pp
+++ b/site/profile/manifests/core/rke.pp
@@ -11,9 +11,9 @@
 #   Version of rke utility to install
 #
 class profile::core::rke (
-  Boolean          $enable_dhcp   = false,
-  Optional[String] $keytab_base64 = undef,
-  String $version                 = '1.3.3',
+  Boolean                        $enable_dhcp   = false,
+  Optional[Sensitive[String[1]]] $keytab_base64 = undef,
+  String                         $version       = '1.3.3',
 ) {
   $user = 'rke'
   $uid  = 75500

--- a/site/profile/manifests/util/keytab.pp
+++ b/site/profile/manifests/util/keytab.pp
@@ -12,7 +12,7 @@
 #
 define profile::util::keytab (
   Integer $uid,
-  String  $keytab_base64,
+  Sensitive[String[1]] $keytab_base64,
 ) {
   $home_path = "/home/${name}"
   $keytab_path = "${home_path}/.keytab"
@@ -24,11 +24,12 @@ define profile::util::keytab (
       mode     => '0700',
   })
   file { $keytab_path:
-    ensure  => file,
-    owner   => $name,
-    group   => $name,
-    mode    => '0400',
-    content => base64('decode', $keytab_base64),
+    ensure    => file,
+    owner     => $name,
+    group     => $name,
+    mode      => '0400',
+    show_diff => false, # do not print keytab in logs
+    content   => base64('decode', $keytab_base64.unwrap),
   }
 
   cron { 'k5start_root':

--- a/site/profile/manifests/util/keytab.pp
+++ b/site/profile/manifests/util/keytab.pp
@@ -33,7 +33,7 @@ define profile::util::keytab (
   }
 
   cron { 'k5start_root':
-    command => "/usr/bin/k5start -f ${keytab_path} -U -o ${uid} -k /tmp/krb5cc_${uid} -H 60 > /dev/null 2>&1",
+    command => "/usr/bin/k5start -f ${keytab_path} -U -o ${uid} -k /tmp/krb5cc_${uid} -H 60 -F > /dev/null 2>&1",
     user    => 'root',
     minute  => '*/1',
     require => File[$keytab_path],

--- a/spec/classes/core/common_spec.rb
+++ b/spec/classes/core/common_spec.rb
@@ -12,6 +12,7 @@ describe 'profile::core::common' do
         it { is_expected.to contain_class('hosts') }
         it { is_expected.to contain_class('network') }
         it { is_expected.to contain_class('resolv_conf') }
+        it { is_expected.to contain_class('profile::core::keytab') }
         it { is_expected.to contain_class('profile::core::nm_dispatch') }
         it { is_expected.to contain_package('ca-certificates').with_ensure('latest') }
 

--- a/spec/classes/core/common_spec.rb
+++ b/spec/classes/core/common_spec.rb
@@ -7,18 +7,43 @@ describe 'profile::core::common' do
     context "on #{os}" do
       let(:facts) { facts }
 
-      it { is_expected.to compile.with_all_deps }
-      it { is_expected.to contain_class('hosts') }
-      it { is_expected.to contain_class('network') }
-      it { is_expected.to contain_class('profile::core::nm_dispatch') }
-      it { is_expected.to contain_package('ca-certificates').with_ensure('latest') }
+      context 'with no params' do
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_class('hosts') }
+        it { is_expected.to contain_class('network') }
+        it { is_expected.to contain_class('resolv_conf') }
+        it { is_expected.to contain_class('profile::core::nm_dispatch') }
+        it { is_expected.to contain_package('ca-certificates').with_ensure('latest') }
 
-      it do
-        is_expected.to contain_service('NetworkManager').with(ensure: 'running', enable: true)
+        it do
+          is_expected.to contain_service('NetworkManager').with(ensure: 'running', enable: true)
+        end
+
+        it do
+          is_expected.to contain_file('/etc/sysconfig/network-scripts/ifcfg-').with_ensure('absent')
+        end
       end
 
-      it do
-        is_expected.to contain_file('/etc/sysconfig/network-scripts/ifcfg-').with_ensure('absent')
+      context 'with resolv_conf param' do
+        context 'when false' do
+          let(:params) do
+            {
+              manage_resolv_conf: false,
+            }
+          end
+
+          it { is_expected.not_to contain_class('resolv_conf') }
+        end
+
+        context 'when true' do
+          let(:params) do
+            {
+              manage_resolv_conf: true,
+            }
+          end
+
+          it { is_expected.to contain_class('resolv_conf') }
+        end
       end
     end
   end

--- a/spec/classes/core/ipa_pwd_reset_spec.rb
+++ b/spec/classes/core/ipa_pwd_reset_spec.rb
@@ -18,10 +18,10 @@ describe 'profile::core::ipa_pwd_reset' do
       context 'with no params' do
         let(:params) do
           {
-            keytab_base64: 'foo',
-            secret_key: 'bar',
-            ldap_user: 'baz',
+            keytab_base64: sensitive('foo'),
             ldap_pwd: 'quix',
+            ldap_user: 'baz',
+            secret_key: 'bar',
           }
         end
 

--- a/spec/classes/core/keytab_spec.rb
+++ b/spec/classes/core/keytab_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'profile::core::keytab' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) do
+        facts
+      end
+
+      context 'with no parameters' do
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to have_profile__util__keytab_resource_count(0) }
+      end
+
+      context 'with keytab param' do
+        let(:params) do
+          {
+            keytab: {
+              foo: {
+                uid: 1234,
+                keytab_base64: sensitive('Zm9v'),
+              },
+            },
+          }
+        end
+
+        it { is_expected.to have_profile__util__keytab_resource_count(1) }
+
+        it do
+          is_expected.to contain_profile__util__keytab('foo').with(
+            uid: 1234,
+            keytab_base64: sensitive('Zm9v'),
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/classes/core/rke_spec.rb
+++ b/spec/classes/core/rke_spec.rb
@@ -67,7 +67,7 @@ describe 'profile::core::rke' do
         context 'when 42' do
           let(:params) do
             {
-              keytab_base64: '42',
+              keytab_base64: sensitive('42'),
             }
           end
 
@@ -76,7 +76,7 @@ describe 'profile::core::rke' do
           it do
             is_expected.to contain_profile__util__keytab('rke').with(
               uid: 75_500,
-              keytab_base64: '42',
+              keytab_base64: sensitive('42'),
             )
           end
         end

--- a/spec/defines/util/keytab_spec.rb
+++ b/spec/defines/util/keytab_spec.rb
@@ -7,7 +7,7 @@ describe 'profile::util::keytab' do
     context "on #{os}" do
       let(:facts) { facts }
       let(:title) { 'foo' }
-      let(:params) { { 'uid' => 123, 'keytab_base64' => 'YmFy' } }
+      let(:params) { { 'uid' => 123, 'keytab_base64' => sensitive('YmFy') } }
 
       it { is_expected.to compile.with_all_deps }
 
@@ -26,6 +26,7 @@ describe 'profile::util::keytab' do
           owner: 'foo',
           group: 'foo',
           mode: '0400',
+          show_diff: false,
           content: 'bar',
         )
       end

--- a/spec/defines/util/keytab_spec.rb
+++ b/spec/defines/util/keytab_spec.rb
@@ -33,7 +33,7 @@ describe 'profile::util::keytab' do
 
       it do
         is_expected.to contain_cron('k5start_root').with(
-          command: '/usr/bin/k5start -f /home/foo/.keytab -U -o 123 -k /tmp/krb5cc_123 -H 60 > /dev/null 2>&1',
+          command: '/usr/bin/k5start -f /home/foo/.keytab -U -o 123 -k /tmp/krb5cc_123 -H 60 -F > /dev/null 2>&1',
         )
       end
 

--- a/spec/fixtures/hieradata/common.yaml
+++ b/spec/fixtures/hieradata/common.yaml
@@ -6,7 +6,6 @@ easy_ipa::directory_services_password: "foofoofoofoo"  # ipa master only
 easy_ipa::domain_join_password: "foofoofoofoo"  # 8 char min
 foreman_proxy::plugin::dns::route53::aws_access_key: "foo"
 foreman_proxy::plugin::dns::route53::aws_secret_key: "foo"
-profile::archive::forwarder::keytab_base64: "foo"
 profile::ccs::krb5_token::keytab_base64: "foo"
 profile::ccs::krb5_token::uid: "foo"
 profile::ccs::krb5_token::user: "foo"

--- a/spec/fixtures/hieradata/common.yaml
+++ b/spec/fixtures/hieradata/common.yaml
@@ -1,4 +1,7 @@
 ---
+lookup_options:
+  '^profile::.+::keytab_base64$':
+    convert_to: "Sensitive"
 ccs_database::database: "comcamdbprod"
 ccs_database::password: "foo"
 easy_ipa::admin_password: "foofoofoofoo"  # ipa master only

--- a/spec/hosts/nodes/tel-hw1.tu.lsst.org_spec.rb
+++ b/spec/hosts/nodes/tel-hw1.tu.lsst.org_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'tel-hw1.tu.lsst.org', :site do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) do
+        facts.merge(
+          fqdn: 'tel-hw1.tu.lsst.org',
+        )
+      end
+
+      let(:node_params) do
+        {
+          role: 'generic',
+          site: 'tu',
+        }
+      end
+
+      it { is_expected.to compile.with_all_deps }
+
+      it do
+        is_expected.to contain_k5login('/home/saluser/.k5login').with(
+          ensure: 'present',
+          principals: ['saluser/tel-lt1.tu.lsst.org@LSST.CLOUD'],
+        )
+      end
+    end # on os
+  end # on_supported_os
+end # role

--- a/spec/hosts/nodes/tel-lt1.tu.lsst.org_spec.rb
+++ b/spec/hosts/nodes/tel-lt1.tu.lsst.org_spec.rb
@@ -20,6 +20,13 @@ describe 'tel-lt1.tu.lsst.org', :site do
 
       it { is_expected.to compile.with_all_deps }
       it { is_expected.not_to contain_class('resolv_conf') }
+
+      it do
+        is_expected.to contain_k5login('/home/saluser/.k5login').with(
+          ensure: 'present',
+          principals: ['saluser/tel-hw1.tu.lsst.org@LSST.CLOUD'],
+        )
+      end
     end # on os
   end # on_supported_os
 end # role

--- a/spec/hosts/nodes/tel-lt1.tu.lsst.org_spec.rb
+++ b/spec/hosts/nodes/tel-lt1.tu.lsst.org_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'tel-lt1.tu.lsst.org', :site do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) do
+        facts.merge(
+          fqdn: 'tel-lt1.tu.lsst.org',
+        )
+      end
+
+      let(:node_params) do
+        {
+          role: 'generic',
+          site: 'tu',
+        }
+      end
+
+      it { is_expected.to compile.with_all_deps }
+      it { is_expected.not_to contain_class('resolv_conf') }
+    end # on os
+  end # on_supported_os
+end # role


### PR DESCRIPTION
Additionally, krb5 keytab values have been converted from `String` to `Sensitive[String]` as a first step towards more considerate handling of secrets.

See: https://puppet.com/docs/puppet/7/securing-sensitive-data.html

Related to https://github.com/lsst-it/lsst-puppet-hiera-private/pull/75