### PR TITLE
(dnscache role) change default bind logging to `notice`

### DIFF
--- a/hieradata/role/dnscache.yaml
+++ b/hieradata/role/dnscache.yaml
@@ -8,7 +8,7 @@ dns::sysconfig_startup_options: "-4"
 dns::additional_directives:
   - "logging {"
   - "    channel queries_syslog {"
-  - "        severity info;"
+  - "        severity notice;"
   - "        print-category yes;"
   - "        syslog local6;"
   - "    };"

--- a/spec/hosts/roles/dnscache_spec.rb
+++ b/spec/hosts/roles/dnscache_spec.rb
@@ -35,6 +35,10 @@ describe "#{role} role" do
               ],
             )
           end
+
+          it do
+            expect(catalogue.resource('class', 'dns')[:additional_directives]).to include(match(%r{^\s+severity notice;$}))
+          end
         end # host
       end # lsst_sites
     end # on os


### PR DESCRIPTION
On EL8, severity level of `info` was causing all queries to be logged.