### PR TITLE
(rke role) ensure br_netfilter kmod is loaded

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -45,6 +45,7 @@ mod 'puppet/epel', '4.1.0'
 mod 'puppet/extlib', '6.0.0'
 mod 'puppetfinland/easy_ipa', git: 'https://github.com/lsst-it/puppet-ipa', ref: 'lsst-2.3.0'  # https://github.com/Puppet-Finland/puppet-ipa/pull/32
 mod 'puppet/ipset', '2.1.0'
+mod 'puppet/kmod', '3.2.0'
 mod 'puppetlabs/accounts', '7.1.1'
 mod 'puppetlabs/apache', '7.0.0'
 mod 'puppetlabs/apt', '8.3.0'

--- a/hieradata/role/rke.yaml
+++ b/hieradata/role/rke.yaml
@@ -18,10 +18,6 @@ packages:
   - "gdisk"
   - "git"
   - "vim"
-sysctl::values::args:
-  net.bridge.bridge-nf-call-iptables:
-    value: 1
-    target: "/etc/sysctl.d/80-rke.conf"
 profile::core::helm::version: "3.5.4"
 profile::core::kernel::devel: true
 profile::core::kernel::debuginfo: true

--- a/site/profile/manifests/core/rke.pp
+++ b/site/profile/manifests/core/rke.pp
@@ -15,6 +15,8 @@ class profile::core::rke (
   Optional[Sensitive[String[1]]] $keytab_base64 = undef,
   String                         $version       = '1.3.3',
 ) {
+  include kmod
+
   $user = 'rke'
   $uid  = 75500
 
@@ -54,4 +56,11 @@ class profile::core::rke (
     version  => $version,
     checksum => $rke_checksum,
   }
+
+  kmod::load { 'br_netfilter': }
+  -> sysctl::value { 'net.bridge.bridge-nf-call-iptables':
+    value  => 1,
+    target => '/etc/sysctl.d/80-rke.conf',
+  }
+  -> Class['docker']
 }

--- a/spec/classes/core/rke_spec.rb
+++ b/spec/classes/core/rke_spec.rb
@@ -6,14 +6,20 @@ describe 'profile::core::rke' do
   on_supported_os.each do |os, facts|
     context "on #{os}" do
       let(:facts) { facts }
+      let(:pre_condition) do
+        <<~PP
+          include docker
+        PP
+      end
 
       context 'with no params' do
         it { is_expected.to compile.with_all_deps }
 
+        include_examples 'rke profile'
+
         it { is_expected.not_to contain_class('cni::plugins') }
         it { is_expected.not_to contain_class('cni::plugins::dhcp') }
         it { is_expected.not_to contain_profile__util__keytab('rke') }
-        it { is_expected.to contain_vcsrepo('/home/rke/k8s-cookbook') }
 
         it do
           is_expected.to contain_class('rke').with(
@@ -33,6 +39,8 @@ describe 'profile::core::rke' do
 
           it { is_expected.to compile.with_all_deps }
 
+          include_examples 'rke profile'
+
           it { is_expected.not_to contain_class('cni::plugins') }
           it { is_expected.not_to contain_class('cni::plugins::dhcp') }
         end
@@ -45,6 +53,8 @@ describe 'profile::core::rke' do
           end
 
           it { is_expected.to compile.with_all_deps }
+
+          include_examples 'rke profile'
 
           it { is_expected.to contain_class('cni::plugins') }
           it { is_expected.to contain_class('cni::plugins::dhcp') }
@@ -61,6 +71,8 @@ describe 'profile::core::rke' do
 
           it { is_expected.to compile.with_all_deps }
 
+          include_examples 'rke profile'
+
           it { is_expected.not_to contain_profile__util__keytab('rke') }
         end
 
@@ -72,6 +84,8 @@ describe 'profile::core::rke' do
           end
 
           it { is_expected.to compile.with_all_deps }
+
+          include_examples 'rke profile'
 
           it do
             is_expected.to contain_profile__util__keytab('rke').with(
@@ -92,6 +106,8 @@ describe 'profile::core::rke' do
 
           it { is_expected.to compile.with_all_deps }
 
+          include_examples 'rke profile'
+
           it do
             is_expected.to contain_class('rke').with(
               version: '1.3.3',
@@ -108,6 +124,8 @@ describe 'profile::core::rke' do
           end
 
           it { is_expected.to compile.with_all_deps }
+
+          include_examples 'rke profile'
 
           it do
             is_expected.to contain_class('rke').with(

--- a/spec/hosts/roles/rke_spec.rb
+++ b/spec/hosts/roles/rke_spec.rb
@@ -5,6 +5,7 @@ require 'spec_helper'
 shared_examples 'generic rke' do
   include_examples 'debugutils'
   include_examples 'docker'
+  include_examples 'rke profile'
 
   it { is_expected.to contain_class('kubectl') }
   it { is_expected.to contain_class('profile::core::rke') }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -350,4 +350,18 @@ shared_examples 'docker' do
   end
 end
 
+shared_examples 'rke profile' do
+  it { is_expected.to contain_vcsrepo('/home/rke/k8s-cookbook') }
+
+  it { is_expected.to contain_kmod__load('br_netfilter') }
+
+  it do
+    is_expected.to contain_sysctl__value('net.bridge.bridge-nf-call-iptables').with(
+      value: 1,
+      target: '/etc/sysctl.d/80-rke.conf',
+    ).that_requires('Kmod::Load[br_netfilter]')
+                                                                              .that_comes_before('Class[docker]')
+  end
+end
+
 # 'spec_overrides' from sync.yml will appear below this line


### PR DESCRIPTION
This mod provides the `net.bridge.bridge-nf-call-iptables` sysctl, which
rke requires be set to a value different than the default.  It seems
that this kmod often isn't loaded until dockerd starts up. This was
causing an order of operations issue with setting
the`net.bridge.bridge-nf-call-iptables` sysctl.