### PR TITLE
(Gemfile) pin console gem version to 1.15.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@
 source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
 group :test do
+  gem 'console', '~> 1.15.3',      require: false
   gem 'coveralls',                 require: false
   gem 'puppet_metadata', '~> 1.0', require: false
   gem 'simplecov-console',         require: false


### PR DESCRIPTION
To resolve this error caused by the rspec-github gem:

    SyntaxError: /opt/hostedtoolcache/Ruby/2.7.2/x64/lib/ruby/gems/2.7.0/gems/console-1.16.2/lib/console/progress.rb:77: syntax error, unexpected ')'
                            @output.info(@subject, ...)
			                          ^