### PR TITLE
manage auditd rules

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -100,6 +100,7 @@ mod 'saz/resolv_conf', '5.0.0'
 mod 'saz/ssh', git: 'https://github.com/lsst-it/saz-puppet-ssh', ref: '7f1a892'  # ssh::client::match_block
 mod 'saz/sudo', '7.0.2'
 mod 'saz/timezone', '6.2.0'
+mod 'simp/auditd', git: 'https://github.com/lsst-it/pupmod-simp-auditd', ref: '1158959'  # https://github.com/simp/pupmod-simp-auditd/pull/160
 mod 'simp/dconf', '0.2.2'
 mod 'simp/gnome', '9.1.0'
 mod 'simp/mate', '1.3.0'

--- a/site/profile/manifests/core/common.pp
+++ b/site/profile/manifests/core/common.pp
@@ -66,6 +66,7 @@ class profile::core::common (
   Boolean $manage_irqbalance = true,
   Boolean $manage_resolv_conf = true,
 ) {
+  include auditd
   include accounts
   include augeas
   include easy_ipa

--- a/spec/classes/core/common_spec.rb
+++ b/spec/classes/core/common_spec.rb
@@ -9,6 +9,7 @@ describe 'profile::core::common' do
 
       context 'with no params' do
         it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_class('auditd') }
         it { is_expected.to contain_class('hosts') }
         it { is_expected.to contain_class('network') }
         it { is_expected.to contain_class('resolv_conf') }

--- a/spec/default_facts.yml
+++ b/spec/default_facts.yml
@@ -3,3 +3,4 @@
 sudoversion: "1.8.23"
 snmp_community: "MhcZxm00k6GjpRedxFnnxA"  #  lsst/ccs_mrtg
 aio_agent_version: "7.18.0"  #  puppetlabs/puppet_agent
+grub_version: "grub2-mkconfig (GRUB) 2.02~beta2"  # simp/auditd


### PR DESCRIPTION
The `simp/auditd` mod includes a default set of auditd rules which appear to be a reasonable starting point.