### PR TITLE
Add Slac routes to on Perfsonar ls interface p2p1 on vlan360 

### DIFF
--- a/hieradata/node/perfsonar1.ls.lsst.org.yaml
+++ b/hieradata/node/perfsonar1.ls.lsst.org.yaml
@@ -118,6 +118,8 @@ network::mroutes_hash:
       "198.32.252.232/31": *via
       "198.32.252.234/31": *via
       "199.36.153.8/30": *via
+      "134.79.235.242/32": *via #slac routes
+      "134.79.235.226/32": *via #slac routes
   p2p2.370:
     #table: 120
     routes:


### PR DESCRIPTION
As per requested on ticket IT-4014 it's needed to add the following routes to interface p2p1 for vlan 360.

`ip route add 134.79.235.242/32 via 139.229.140.134 dev p2p1.360`
`ip route add 134.79.235.226/32 via 139.229.140.134 dev p2p1.360`