### PR TITLE
(docker-compose role) use docker-compose package

### DIFF
--- a/hieradata/role/amor.yaml
+++ b/hieradata/role/amor.yaml
@@ -3,24 +3,8 @@ classes:
   - "profile::core::common"
   - "profile::core::debugutils"
   - "profile::core::docker"
+  - "profile::core::docker::compose"
   - "profile::core::docker::prune"
   - "profile::core::nfsclient"
-  - "python"
-
-# install docker-compose at system level
-python::version: "python36"
-python::pip: "present"
-python::dev: "present"
-python::venv: "present"
-# docker-compose is python3 only
-python::python_pips:
-  "docker-compose":
-    virtualenv: "system"
-    ensure: "1.25.0"
-    pip_provider: "pip3"
-  "cryptography":
-    virtualenv: "system"
-    ensure: "3.3"
-    pip_provider: "pip3"
 packages:
   - "git"

--- a/hieradata/role/docker-compose.yaml
+++ b/hieradata/role/docker-compose.yaml
@@ -2,20 +2,5 @@
 classes:
   - "profile::core::common"
   - "profile::core::docker"
+  - "profile::core::docker::compose"
   - "profile::core::docker::prune"
-  - "python"
-# install docker-compose at system level
-python::version: "python36"
-python::pip: "present"
-python::dev: "present"
-python::venv: "present"
-# docker-compose is python3 only
-python::python_pips:
-  "docker-compose":
-    virtualenv: "system"
-    ensure: "1.25.0"
-    pip_provider: "pip3"
-  "cryptography":
-    virtualenv: "system"
-    ensure: "3.3"
-    pip_provider: "pip3"

--- a/hieradata/role/hexrot.yaml
+++ b/hieradata/role/hexrot.yaml
@@ -3,11 +3,11 @@ classes:
   - "profile::core::common"
   - "profile::core::debugutils"
   - "profile::core::docker"
+  - "profile::core::docker::compose"
   - "profile::core::docker::prune"
   - "profile::core::ni_packages"
   - "profile::core::x2go_agent"
   - "profile::ts::nexusctio"
-  - "python"
 files:
   /rubin:
     ensure: "directory"
@@ -21,21 +21,6 @@ files:
 # / on hexrot.cp was formated with xfs fstype=0 (long, long, long ago) and is
 # not compatible with overlayfs[2]
 profile::core::docker::storage_driver: "devicemapper"
-# install docker-compose at system level
-python::version: "python36"
-python::pip: "present"
-python::dev: "present"
-python::venv: "present"
-python::python_pips:
-  # docker-compose is python3 only
-  "docker-compose":
-    virtualenv: "system"
-    ensure: "1.25.0"
-    pip_provider: "pip3"
-  "cryptography":
-    virtualenv: "system"
-    ensure: "3.3"
-    pip_provider: "pip3"
 accounts::group_list:
   # this is duplicating the ipa gid as a local group
   &docker_name docker-%{facts.hostname}:

--- a/hieradata/role/ts-csc.yaml
+++ b/hieradata/role/ts-csc.yaml
@@ -2,25 +2,8 @@
 classes:
   - "profile::core::common"
   - "profile::core::docker"
+  - "profile::core::docker::compose"
   - "profile::core::docker::prune"
   - "profile::nfs::client::csc"
-  - "python"
-
 packages:
   - "git"
-
-# install docker-compose at system level
-python::version: "python36"
-python::pip: "present"
-python::dev: "present"
-python::venv: "present"
-# docker-compose is python3 only
-python::python_pips:
-  "docker-compose":
-    virtualenv: "system"
-    ensure: "1.25.0"
-    pip_provider: "pip3"
-  "cryptography":
-    virtualenv: "system"
-    ensure: "3.3"
-    pip_provider: "pip3"

--- a/site/profile/manifests/core/docker/compose.pp
+++ b/site/profile/manifests/core/docker/compose.pp
@@ -1,0 +1,6 @@
+# @summary
+#   Install `docker-compose` utility
+#
+class profile::core::docker::compose {
+  ensure_packages(['docker-compose-plugin'])
+}

--- a/spec/classes/core/docker/compose_spec.rb
+++ b/spec/classes/core/docker/compose_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'profile::core::docker::compose' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) do
+        facts
+      end
+
+      context 'with no parameters' do
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_package('docker-compose-plugin') }
+      end
+    end
+  end
+end

--- a/spec/hosts/roles/amor_spec.rb
+++ b/spec/hosts/roles/amor_spec.rb
@@ -28,8 +28,9 @@ describe "#{role} role" do
           it { is_expected.to compile.with_all_deps }
 
           include_examples 'common', facts: facts
-
           include_examples 'docker'
+
+          it { is_expected.to contain_package('docker-compose-plugin') }
         end # host
       end # lsst_sites
     end # on os

--- a/spec/hosts/roles/docker_compose_spec.rb
+++ b/spec/hosts/roles/docker_compose_spec.rb
@@ -28,6 +28,8 @@ describe "#{role} role" do
 
           include_examples 'common', facts: facts
           include_examples 'docker'
+
+          it { is_expected.to contain_package('docker-compose-plugin') }
         end # host
       end # lsst_sites
     end # on os

--- a/spec/hosts/roles/hexrot_spec.rb
+++ b/spec/hosts/roles/hexrot_spec.rb
@@ -38,10 +38,11 @@ describe "#{role} role" do
             profile::core::docker::prune
             profile::core::ni_packages
             profile::core::x2go_agent
-            python
           ].each do |c|
             it { is_expected.to contain_class(c) }
           end
+
+          it { is_expected.to contain_package('docker-compose-plugin') }
         end # host
       end # lsst_sites
     end # on os

--- a/spec/hosts/roles/ts_csc_spec.rb
+++ b/spec/hosts/roles/ts_csc_spec.rb
@@ -28,8 +28,9 @@ describe "#{role} role" do
           it { is_expected.to compile.with_all_deps }
 
           include_examples 'common', facts: facts
-
           include_examples 'docker'
+
+          it { is_expected.to contain_package('docker-compose-plugin') }
         end # host
       end # lsst_sites
     end # on os


### PR DESCRIPTION
Instead of manual installation of `docker-compose` using pip.

To resolve this error:

    Error: 'pip3 --log /tmp/pip.log install     docker-compose==1.25.0' returned 1 instead of one of [0]
    Error: /Stage[main]/Python/Python::Pip[docker-compose]/Exec[pip_install_docker-compose]/returns: change from 'notrun' to ['0'] failed: 'pip3 --log /tmp/pip.log install     docker-compose==1.25.0' returned 1 instead of one of [0] (corrective)