### PR TITLE
(Puppetfile) bump puppet/yum to 6.1.0

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -93,7 +93,7 @@ mod 'puppet/selinux', '3.4.1'
 mod 'puppet/ssh_keygen', '5.0.2'
 mod 'puppet/systemd', '3.8.0'
 mod 'puppet/telegraf', '4.2.0'  # requires toml-rb installed on master
-mod 'puppet/yum', '5.6.1'
+mod 'puppet/yum', '6.1.0'
 mod 'qtechnologies/sysstat', '1.2.4'
 mod 'richardc/datacat', '0.6.2'
 mod 'saz/resolv_conf', '5.0.0'


### PR DESCRIPTION
To pickup AlmaLinux 9 support.

Depends upon:
-  https://github.com/lsst-it/puppet-java_artisanal/pull/13
- #699 