### PR TITLE
(gha) switch to 16 core runner

### DIFF
--- a/.github/workflows/rake_checks.yaml
+++ b/.github/workflows/rake_checks.yaml
@@ -7,7 +7,9 @@ name: rake checks
 
 jobs:
   rake_checks:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: Default Larger Runners
+      labels: ubuntu-latest-16-cores
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
The gha run time is already > 10 minutes with only two OS in the test matrix (EL7 & EL8) when using the default gha runner.  It is hoped that switching to the 16c runner will reduce the time for all gha workflows to run to < 10 minutes.