### PR TITLE
bump docker to 20.10.21

### DIFF
--- a/site/profile/data/common.yaml
+++ b/site/profile/data/common.yaml
@@ -110,7 +110,7 @@ profile::core::yum::lsst_ts_private::repos:
     gpgcheck: false
     target: "/etc/yum.repos.d/lsst-ts-private.repo"
 
-profile::core::docker::version: "20.10.12"
+profile::core::docker::version: "20.10.21"
 
 profile::core::sysctl::lhn::sysctls:
   # lhn tuning

--- a/site/profile/data/osfamily/RedHat/major/7.yaml
+++ b/site/profile/data/osfamily/RedHat/major/7.yaml
@@ -7,7 +7,7 @@ profile::core::docker::versionlock:
   containerd.io:
     # puppetlabs/docker only specifies a package resource for containerd.io for uninstall
     ensure: "present"
-    version: "1.4.12"
+    version: "1.6.10"
     release: "3.1.el7"
   docker-ce:
     ensure: "present"

--- a/site/profile/data/osfamily/RedHat/major/7.yaml
+++ b/site/profile/data/osfamily/RedHat/major/7.yaml
@@ -28,5 +28,5 @@ profile::core::docker::versionlock:
     release: *docker_release
   docker-scan-plugin:
     ensure: "present"
-    version: "0.12.0"
+    version: "0.21.0"
     release: *docker_release

--- a/site/profile/data/osfamily/RedHat/major/8.yaml
+++ b/site/profile/data/osfamily/RedHat/major/8.yaml
@@ -6,7 +6,7 @@ profile::core::docker::versionlock:
   containerd.io:
     # puppetlabs/docker only specifies a package resource for containerd.io for uninstall
     ensure: "present"
-    version: "1.4.12"
+    version: "1.6.10"
     release: "3.1.el8"
   docker-ce:
     ensure: "present"

--- a/site/profile/data/osfamily/RedHat/major/8.yaml
+++ b/site/profile/data/osfamily/RedHat/major/8.yaml
@@ -27,5 +27,5 @@ profile::core::docker::versionlock:
     release: *docker_release
   docker-scan-plugin:
     ensure: "present"
-    version: "0.12.0"
+    version: "0.21.0"
     release: *docker_release

--- a/site/profile/data/osfamily/RedHat/major/9.yaml
+++ b/site/profile/data/osfamily/RedHat/major/9.yaml
@@ -1,3 +1,31 @@
 ---
 profile::core::bash_completion::packages:
   - "bash-completion"
+
+profile::core::docker::versionlock:
+  containerd.io:
+    # puppetlabs/docker only specifies a package resource for containerd.io for uninstall
+    ensure: "present"
+    version: "1.6.9"
+    release: "3.1.el9"
+  docker-ce:
+    ensure: "present"
+    epoch: 3
+    version: "%{lookup('profile::core::docker::version')}"
+    release: &docker_release "3.el9"
+    # the puppet package resource name is `docker` with a seperate name param of `docker-ce`
+    before: "Package[docker]"
+  docker-ce-cli:
+    ensure: "present"
+    epoch: 1
+    version: "%{lookup('profile::core::docker::version')}"
+    release: *docker_release
+    before: "Package[docker-ce-cli]"
+  docker-ce-rootless-extras:
+    ensure: "present"
+    version: "%{lookup('profile::core::docker::version')}"
+    release: *docker_release
+  docker-scan-plugin:
+    ensure: "present"
+    version: "0.21.0"
+    release: *docker_release

--- a/site/profile/data/osfamily/RedHat/major/9.yaml
+++ b/site/profile/data/osfamily/RedHat/major/9.yaml
@@ -6,7 +6,7 @@ profile::core::docker::versionlock:
   containerd.io:
     # puppetlabs/docker only specifies a package resource for containerd.io for uninstall
     ensure: "present"
-    version: "1.6.9"
+    version: "1.6.10"
     release: "3.1.el9"
   docker-ce:
     ensure: "present"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -383,7 +383,7 @@ shared_examples 'puppet_master' do
 end
 
 shared_examples 'docker' do
-  docker_version = '20.10.12'
+  docker_version = '20.10.21'
 
   it do
     is_expected.to contain_class('docker').with(

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -408,13 +408,13 @@ shared_examples 'docker' do
 
   it do
     is_expected.to contain_yum__versionlock('containerd.io').with(
-      version: '1.4.12',
+      version: '1.6.10',
     )
   end
 
   it do
     is_expected.to contain_yum__versionlock('docker-scan-plugin').with(
-      version: '0.12.0',
+      version: '0.21.0',
     )
   end
 end


### PR DESCRIPTION
The currently pinned version, 20.10.12, does not have packages for EL9.
We are updating to a version that has packages for EL7, EL8, & EL9.

Based on #702 