### PR TITLE
disable icinga on EL9

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -299,7 +299,7 @@ yum::manage_os_default_repos: true
 
 letsencrypt::email: "rubinobs-it-las@lsst.org"
 profile::icinga::agent::host_template: "GeneralHostTemplate"
-profile::core::common::deploy_icinga_agent: false
+profile::core::common::deploy_icinga_agent: true
 
 profile::core::ipset::set:
   # lsst/aura "internal" prefixes

--- a/hieradata/common/osfamily/RedHat/major/9.yaml
+++ b/hieradata/common/osfamily/RedHat/major/9.yaml
@@ -5,3 +5,4 @@ profile::core::yum::versionlock:
     version: "7.18.0"
     release: "1.el9"
     before: "Package[puppet-agent]"
+profile::core::common::deploy_icinga_agent: false

--- a/hieradata/site/cp.yaml
+++ b/hieradata/site/cp.yaml
@@ -103,7 +103,6 @@ accounts::user_list:
       # foreman-proxy
       - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDN16b56V3j7wot509IlRvOFXaLxI9AH9/eOr1WuLEdpGoQ3lDuz26P6zFLbopjgsZxdzxE492QAmGpdUkn+Ducny1JK83L0N/d6INrM48fQeiUiSsN/YKua9qO8QQbvTsiiKanj38u9x1vOfqKn2/kK7BKAZblr+qT7U6nofMFlG3zJpNOCAIHyd4DJRrWB+xPR1YRwljV6BOtpI5+/FwdoX+/61cdsP0895iejDlnYRNFBYWRdGHDdDN6yfSNy00D/ADwaZP9sO+gyvHPqz/saPFYx8Petbhl/PlUjqWx7sktQxPgpMPBU/KQU5SEd5RkcT+CVjLHuHfOa3jXEdVx foreman-proxy@foreman.cp.lsst.org"
 
-profile::core::common::deploy_icinga_agent: true
 profile::icinga::agent::icinga_master_fqdn: "icinga-master.cp.lsst.org"
 profile::icinga::agent::icinga_master_ip: "139.229.160.31"
 profile::icinga::agent::site: "summit"

--- a/hieradata/site/dev.yaml
+++ b/hieradata/site/dev.yaml
@@ -114,7 +114,6 @@ accounts::user_list:
       - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDIAmA8aQ9Qf8ok+zPUSwFWfEgNxUW1RptUhZE9/9PFGzhAi7XMnt6qaSFINlLxiECUXKeK3iwHI3rLxMsJpcGRGkkL9GGpUYNgyDVZt82AFN2rt7nvuYqm9M7M4Q6NeLlMEGUf9iSnzE/IpT4459iOiKdaB3SifuXWjJeUSOoNACugJcQCZm4nQGo9ZUVJcbhYael++pcobApctOOFjlaVi6s+iB4qdidMJ9CUEyQ8HBSDomBnj2dZ5QB/bDHUW1OKo/i+LbMdF1HrnEcI9AkSHfkW+OP7L5mkmRJBNsK5R6YzIb41LHCvO1Fvoinb71JkWD5ElzTLY5e7YkjRXkQV foreman-proxy@foreman.dev.lsst.org"
 
 letsencrypt::server: "https://acme-staging.api.letsencrypt.org/directory"  # testing url
-profile::core::common::deploy_icinga_agent: true
 profile::core::common::disable_ipv6: true
 profile::icinga::agent::icinga_master_fqdn: "icinga-master.ls.lsst.org"
 profile::icinga::agent::icinga_master_ip: "139.229.135.31"

--- a/hieradata/site/ls.yaml
+++ b/hieradata/site/ls.yaml
@@ -101,7 +101,6 @@ accounts::user_list:
       # foreman-proxy
       - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDsF9VQ7wjm0Rm/1HA6Zc94IAkhqol5cwT44MwwR6uzDyo+/tqa8awUnmVF+RyiJaR6NEKO6YhjkIPga7rDQJerCMLg/xfFzpRcKSi+Xw5YCQ3Z+4P8XZrICM2vzDV6rBELl4n8Bzk6ncXOcKwbUitw3aj6bJNduv6hGrhkJKlWob+cXGH+KZwDiLX82hxsWmktRWcwDEaXTFWq6dahg3/0niAojkfo2ZlJtRblSEgUBf7JITeXBGYAunAeUYE93xUC9tB1OIzisQLQKCFM2OgSjnO4NSx2r4nIPYhEOEhBnNBqF9mPqalRjoyimvF+lu/vsZ43r7nZyV4RwYbyfmVL foreman-proxy@foreman.ls.lsst.org"
 
-profile::core::common::deploy_icinga_agent: true
 profile::core::common::disable_ipv6: true
 profile::icinga::agent::icinga_master_fqdn: "icinga-master.ls.lsst.org"
 profile::icinga::agent::icinga_master_ip: "139.229.135.31"

--- a/hieradata/site/tu.yaml
+++ b/hieradata/site/tu.yaml
@@ -83,7 +83,6 @@ accounts::user_list:
       - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCjbrCz3m21/gVUH34zoLsxzL1gYuVRNngZ5P6/3/Iw8LR0eMRmkqDZGDR27R91xQSQ4iazP35yeeWH18y+GLUXgfskjYpwqHZ+JBhnaYBoAUaogXYw2FGZAlvjtKZlFclSXu16jKq5sF0woDC6KBxRJuu24EuL2QY9pGPReFGNwgYmruhIDeRZpj/vy7+2+L/hqXTcq42xRMUYRLomR8C7LXkZvrH59QuWYh71Nsx8Qko901c/qpgEynu4ZQFOrSVRgEWPls/Y/aWSAT1k68tGaFQ+W0CP7CA2pbR+ZjcxbodXMoOwxUgHbhR3SwNpGeKEtKh4Csd5e6pgIskW2kX7 root@foreman.tuc.lsst.cloud"
 
 profile::core::common::manage_powertop: true
-profile::core::common::deploy_icinga_agent: true
 profile::icinga::agent::icinga_master_fqdn: "icinga-master.ls.lsst.org"
 profile::icinga::agent::icinga_master_ip: "139.229.135.31"
 profile::icinga::agent::site: "base"


### PR DESCRIPTION
There are no freely available official packages built/published for EL9 as icinga has decided to place them behind a paywall.  We need to consider if we want to build our own rpms from source, license icinga, or migrate to a different solution. In the meantime, we need to disable attempting to manage icinga on EL9 via puppet.

See: https://github.com/Icinga/icinga2/issues/9390

Based on #704 