### PR TITLE
(profile::core::debugutils) drop tuned-utils-systemtap package

### DIFF
--- a/site/profile/data/common.yaml
+++ b/site/profile/data/common.yaml
@@ -27,7 +27,6 @@ profile::core::debugutils::packages:
   - "tcpdump"
   - "traceroute"
   - "tree"
-  - "tuned-utils-systemtap"
   - "usbutils"
 profile::ccs::postfix::packages:
   # required for postfix sasl auth


### PR DESCRIPTION
As this package isn't present on EL9 and it is unclear if we have ever used this package.