### PR TITLE
(rke role) restrict inclusion of clustershell class to EL7/EL8

### DIFF
--- a/hieradata/role/rke.yaml
+++ b/hieradata/role/rke.yaml
@@ -1,6 +1,5 @@
 ---
 classes:
-  - "clustershell"
   - "kubectl"
   - "profile::core::common"
   - "profile::core::debugutils"

--- a/hieradata/role/rke/osfamily/RedHat/major/7.yaml
+++ b/hieradata/role/rke/osfamily/RedHat/major/7.yaml
@@ -1,0 +1,3 @@
+---
+classes:
+  - "clustershell"

--- a/hieradata/role/rke/osfamily/RedHat/major/8.yaml
+++ b/hieradata/role/rke/osfamily/RedHat/major/8.yaml
@@ -1,0 +1,3 @@
+---
+classes:
+  - "clustershell"

--- a/spec/hosts/roles/rke_spec.rb
+++ b/spec/hosts/roles/rke_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-shared_examples 'generic rke' do
+shared_examples 'generic rke' do |facts:|
   include_examples 'debugutils'
   include_examples 'docker'
   include_examples 'rke profile'
@@ -14,6 +14,14 @@ shared_examples 'generic rke' do
     is_expected.to contain_file('/home/rke/.bashrc.d/kubectl.sh')
       .with_content(%r{^alias k='kubectl'$})
       .with_content(%r{^complete -o default -F __start_kubectl k$})
+  end
+
+  if facts[:os]['family'] == 'RedHat'
+    if facts[:os]['release']['major'] == '9'
+      it { is_expected.not_to contain_class('clustershell') }
+    else
+      it { is_expected.to contain_class('clustershell') }
+    end
   end
 end
 
@@ -42,8 +50,7 @@ describe "#{role} role" do
           it { is_expected.to compile.with_all_deps }
 
           include_examples 'common', facts: facts
-
-          include_examples 'generic rke'
+          include_examples 'generic rke', facts: facts
         end # host
       end # lsst_sites
 
@@ -61,7 +68,7 @@ describe "#{role} role" do
           it { is_expected.to compile.with_all_deps }
 
           include_examples 'common', facts: facts
-          include_examples 'generic rke'
+          include_examples 'generic rke', facts: facts
         end
       end
     end # on os


### PR DESCRIPTION
There does not [yet] appear to be a clustershell package in EPEL9.