### PR TITLE
(profile::core::rke) drop class level require of easy_ipa

### DIFF
--- a/site/profile/manifests/core/rke.pp
+++ b/site/profile/manifests/core/rke.pp
@@ -5,7 +5,7 @@
 #   Enable CNI dhcp plugin
 #
 # @param keytab_base64
-#   base64 encoded krb5 keytab for the iip user
+#   base64 encoded krb5 keytab
 #
 # @param version
 #   Version of rke utility to install
@@ -15,8 +15,6 @@ class profile::core::rke (
   Optional[Sensitive[String[1]]] $keytab_base64 = undef,
   String                         $version       = '1.3.3',
 ) {
-  # ipa must be setup to use the rke user
-  require easy_ipa
   include kmod
 
   $user = 'rke'
@@ -31,6 +29,7 @@ class profile::core::rke (
     profile::util::keytab { $user:
       uid           => $uid,
       keytab_base64 => $keytab_base64,
+      require       => Class[easy_ipa], # ipa must be setup to use the rke user
     }
   }
 
@@ -42,6 +41,7 @@ class profile::core::rke (
     user               => $user,
     owner              => $user,
     group              => $user,
+    require            => Class[easy_ipa], # ipa must be setup to use the rke user
   }
 
   $rke_checksum = $version ? {

--- a/spec/classes/core/rke_spec.rb
+++ b/spec/classes/core/rke_spec.rb
@@ -9,6 +9,7 @@ describe 'profile::core::rke' do
       let(:pre_condition) do
         <<~PP
           include docker
+          include easy_ipa
           include sssd
         PP
       end
@@ -20,7 +21,11 @@ describe 'profile::core::rke' do
 
         it { is_expected.not_to contain_class('cni::plugins') }
         it { is_expected.not_to contain_class('cni::plugins::dhcp') }
-        it { is_expected.not_to contain_profile__util__keytab('rke') }
+
+        it do
+          is_expected.not_to contain_profile__util__keytab('rke')
+            .that_requires('Class[easy_ipa]')
+        end
 
         it do
           is_expected.to contain_class('rke').with(

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -428,13 +428,11 @@ shared_examples 'rke profile' do
     is_expected.to contain_sysctl__value('net.bridge.bridge-nf-call-iptables').with(
       value: 1,
       target: '/etc/sysctl.d/80-rke.conf',
-    ).that_requires('Kmod::Load[br_netfilter]')
-                                                                              .that_comes_before('Class[docker]')
+    ).that_requires('Kmod::Load[br_netfilter]').that_comes_before('Class[docker]')
   end
 
   it do
-    is_expected.to contain_class('easy_ipa')
-      .that_comes_before('Class[profile::core::rke]')
+    is_expected.to contain_vcsrepo('/home/rke/k8s-cookbook').that_requires('Class[easy_ipa]')
   end
 end
 


### PR DESCRIPTION
The class level require was effectively blocking the docker class resources if easy_ipa fails to install.  Instead of the entire class requiring easy_ipa, we are adding the require metaparam to two resources that need ipa user name resolution to be functioning.