### PR TITLE
add EL9 Network Config Manke Cluster

### DIFF
--- a/hieradata/cluster/manke.yaml
+++ b/hieradata/cluster/manke.yaml
@@ -1,0 +1,9 @@
+---
+clustershell::groupmembers:
+  manke: {group: "manke", member: "manke[01-10]"}
+cni::plugins::checksum: "962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7"
+cni::plugins::enable: ["macvlan"]
+cni::plugins::version: "0.9.1"
+profile::core::common::manage_powertop: true
+profile::core::ospl::enable_rundir: true
+profile::core::rke::enable_dhcp: true

--- a/hieradata/cluster/manke.yaml
+++ b/hieradata/cluster/manke.yaml
@@ -7,3 +7,4 @@ cni::plugins::version: "0.9.1"
 profile::core::common::manage_powertop: true
 profile::core::ospl::enable_rundir: true
 profile::core::rke::enable_dhcp: true
+profile::core::rke::version: "1.4.1"

--- a/hieradata/cluster/manke/osfamily/RedHat/major/9.yaml
+++ b/hieradata/cluster/manke/osfamily/RedHat/major/9.yaml
@@ -27,3 +27,6 @@ profile::nm::connections:
       interface-name=enp129s0f1
 
       [ethernet]
+
+      [ipv4]
+      method=disabled

--- a/hieradata/cluster/manke/osfamily/RedHat/major/9.yaml
+++ b/hieradata/cluster/manke/osfamily/RedHat/major/9.yaml
@@ -1,9 +1,4 @@
 ---
-cni::plugins::checksum: "962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7"
-cni::plugins::enable: ["macvlan"]
-cni::plugins::version: "0.9.1"
-profile::core::rke::enable_dhcp: true
-profile::core::ospl::enable_rundir: true
 profile::nm::connections:
   enp129s0f0:
     content: |

--- a/hieradata/cluster/manke/osfamily/RedHat/major/9.yaml
+++ b/hieradata/cluster/manke/osfamily/RedHat/major/9.yaml
@@ -1,0 +1,29 @@
+---
+cni::plugins::checksum: "962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7"
+cni::plugins::enable: ["macvlan"]
+cni::plugins::version: "0.9.1"
+profile::core::rke::enable_dhcp: true
+profile::core::ospl::enable_rundir: true
+profile::nm::connections:
+  enp129s0f0:
+    content: |
+      [connection]
+      id=enp129s0f0
+      uuid=bcbc933f-bf6f-4000-9dc6-7d39712f8c48
+      type=ethernet
+      autoconnect=true
+      interface-name=enp129s0f0
+
+      [ethernet]
+
+      [ipv4]
+      method=auto
+  enp129s0f1:
+    content: |
+      [connection]
+      id=enp129s0f1
+      uuid=1b088f39-bc59-4dcc-9a85-f962c935eaeb
+      type=ethernet
+      interface-name=enp129s0f1
+
+      [ethernet]

--- a/hieradata/cluster/manke/osfamily/RedHat/major/9.yaml
+++ b/hieradata/cluster/manke/osfamily/RedHat/major/9.yaml
@@ -18,6 +18,9 @@ profile::nm::connections:
 
       [ipv4]
       method=auto
+
+      [ipv6]
+      method=disabled
   enp129s0f1:
     content: |
       [connection]
@@ -29,4 +32,7 @@ profile::nm::connections:
       [ethernet]
 
       [ipv4]
+      method=disabled
+
+      [ipv6]
       method=disabled

--- a/site/profile/manifests/core/rke.pp
+++ b/site/profile/manifests/core/rke.pp
@@ -48,6 +48,7 @@ class profile::core::rke (
     '1.3.3'  => '61088847d80292f305e233b7dff4ac8e47fefdd726e5245052450bf05da844aa',
     '1.3.6'  => 'c02a8dd7405e3729e004bb1d551fda4c1437f5e0e8279ea67efba8056c0d4898',
     '1.3.12' => '579da2206aec09cadccd8d6f4818861e78a256b6ae550a229335e500a472bd50',
+    '1.4.1'  => '0db4be307e64549fe2e72b955562df52335b9895cc7ec838927991403f86c7c2',
     default  => undef,
   }
   unless ($rke_checksum) {

--- a/spec/hosts/cluster/manke/manke_spec.rb
+++ b/spec/hosts/cluster/manke/manke_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe "manke cluster" do
+  let(:node_params) do
+    {
+       role: 'rke',
+       site: 'ls',
+       cluster: 'manke',
+    }
+  end
+
+  %w[
+    enp129s0f0
+    enp129s0f1
+  ].each do |int|
+    it do
+      is_expected.to contain_network__interface(int)
+        .with_ensure('present')
+    end
+  end
+end


### PR DESCRIPTION
adds the basic initial configuration for network interfaces, this could probably be moved to another hierarchy.