### PR TITLE
(profile::core::common) enable NetworkManager support on EL9 by default

### DIFF
--- a/hieradata/role/rke/osfamily/RedHat/major/9.yaml
+++ b/hieradata/role/rke/osfamily/RedHat/major/9.yaml
@@ -1,4 +1,3 @@
 ---
 classes:
   - "profile::nm"
-profile::core::common::manage_network: false

--- a/hieradata/role/rke/osfamily/RedHat/major/9.yaml
+++ b/hieradata/role/rke/osfamily/RedHat/major/9.yaml
@@ -1,3 +1,0 @@
----
-classes:
-  - "profile::nm"

--- a/site/profile/manifests/core/common.pp
+++ b/site/profile/manifests/core/common.pp
@@ -117,12 +117,17 @@ class profile::core::common (
             include scl
           }
         }
+
+        if $manage_network {
+          include network
+        }
       }
       '8': {
         # On EL8+, the NetworkManager-initscripts-updown package provides the
         # ifup/ifdown scripts which are needed by example42/network.
         ensure_packages(['NetworkManager-initscripts-updown'])
         if $manage_network {
+          include network
           Package['NetworkManager-initscripts-updown'] -> Class['network']
         }
       }
@@ -187,10 +192,6 @@ class profile::core::common (
 
   if $manage_resolv_conf {
     include resolv_conf
-  }
-
-  if $manage_network {
-    include network
   }
 
   unless $facts['is_virtual'] {

--- a/site/profile/manifests/core/common.pp
+++ b/site/profile/manifests/core/common.pp
@@ -50,7 +50,7 @@
 #   If `true`, manage resolv.conf
 #
 # @param manage_network
-#   If `true`, manage /etc/sysconfig/network-scripts
+#   If `true`, manage network configuration
 #
 class profile::core::common (
   Boolean $deploy_icinga_agent = false,
@@ -130,6 +130,9 @@ class profile::core::common (
           include network
           Package['NetworkManager-initscripts-updown'] -> Class['network']
         }
+      }
+      default: { # EL9+
+        include profile::nm
       }
     }
   }

--- a/site/profile/manifests/core/common.pp
+++ b/site/profile/manifests/core/common.pp
@@ -118,7 +118,7 @@ class profile::core::common (
           }
         }
       }
-      default: {
+      '8': {
         # On EL8+, the NetworkManager-initscripts-updown package provides the
         # ifup/ifdown scripts which are needed by example42/network.
         ensure_packages(['NetworkManager-initscripts-updown'])

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -187,8 +187,7 @@ shared_examples 'common' do |facts:, no_auth: false, chrony: true|
 
     if facts[:os]['release']['major'] == '9'
       it { is_expected.to contain_class('lldpd').with_manage_repo(false) }
-
-      it { is_expected.to contain_package('NetworkManager-initscripts-updown') }
+      it { is_expected.not_to contain_package('NetworkManager-initscripts-updown') }
     end
   else # not osfamily RedHat
     it { is_expected.not_to contain_class('epel') }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -166,6 +166,7 @@ shared_examples 'common' do |facts:, no_auth: false, chrony: true|
       it { is_expected.to contain_class('yum').with_managed_repos(['extras']) }
       it { is_expected.to contain_class('lldpd').with_manage_repo(true) }
       it { is_expected.to contain_class('network') }
+      it { is_expected.not_to contain_class('profile::nm') }
 
       if facts[:os]['architecture'] == 'x86_64'
         it { is_expected.to contain_class('scl') }
@@ -180,6 +181,7 @@ shared_examples 'common' do |facts:, no_auth: false, chrony: true|
     if facts[:os]['release']['major'] == '8'
       it { is_expected.to contain_class('lldpd').with_manage_repo(true) }
       it { is_expected.to contain_class('network') }
+      it { is_expected.not_to contain_class('profile::nm') }
 
       it do
         is_expected.to contain_package('NetworkManager-initscripts-updown')
@@ -191,6 +193,7 @@ shared_examples 'common' do |facts:, no_auth: false, chrony: true|
       it { is_expected.to contain_class('lldpd').with_manage_repo(false) }
       it { is_expected.not_to contain_class('network') }
       it { is_expected.not_to contain_package('NetworkManager-initscripts-updown') }
+      it { is_expected.to contain_class('profile::nm') }
     end
   else # not osfamily RedHat
     it { is_expected.not_to contain_class('epel') }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -165,6 +165,7 @@ shared_examples 'common' do |facts:, no_auth: false, chrony: true|
       it { is_expected.not_to contain_package('NetworkManager-initscripts-updown') }
       it { is_expected.to contain_class('yum').with_managed_repos(['extras']) }
       it { is_expected.to contain_class('lldpd').with_manage_repo(true) }
+      it { is_expected.to contain_class('network') }
 
       if facts[:os]['architecture'] == 'x86_64'
         it { is_expected.to contain_class('scl') }
@@ -178,6 +179,7 @@ shared_examples 'common' do |facts:, no_auth: false, chrony: true|
 
     if facts[:os]['release']['major'] == '8'
       it { is_expected.to contain_class('lldpd').with_manage_repo(true) }
+      it { is_expected.to contain_class('network') }
 
       it do
         is_expected.to contain_package('NetworkManager-initscripts-updown')
@@ -187,6 +189,7 @@ shared_examples 'common' do |facts:, no_auth: false, chrony: true|
 
     if facts[:os]['release']['major'] == '9'
       it { is_expected.to contain_class('lldpd').with_manage_repo(false) }
+      it { is_expected.not_to contain_class('network') }
       it { is_expected.not_to contain_package('NetworkManager-initscripts-updown') }
     end
   else # not osfamily RedHat


### PR DESCRIPTION
This change will enable NetworkManager support on EL9 nodes by default. The current scheme requires each role to "opt-in" to NM support.