### PR TITLE
(rke role) install clustershell on EL9

### DIFF
--- a/hieradata/role/rke.yaml
+++ b/hieradata/role/rke.yaml
@@ -1,5 +1,6 @@
 ---
 classes:
+  - "clustershell"
   - "kubectl"
   - "profile::core::common"
   - "profile::core::debugutils"

--- a/hieradata/role/rke/osfamily/RedHat/major/7.yaml
+++ b/hieradata/role/rke/osfamily/RedHat/major/7.yaml
@@ -1,3 +1,0 @@
----
-classes:
-  - "clustershell"

--- a/hieradata/role/rke/osfamily/RedHat/major/8.yaml
+++ b/hieradata/role/rke/osfamily/RedHat/major/8.yaml
@@ -1,3 +1,0 @@
----
-classes:
-  - "clustershell"

--- a/spec/hosts/roles/rke_spec.rb
+++ b/spec/hosts/roles/rke_spec.rb
@@ -9,6 +9,7 @@ shared_examples 'generic rke' do |facts:|
 
   it { is_expected.to contain_class('kubectl') }
   it { is_expected.to contain_class('profile::core::rke') }
+  it { is_expected.to contain_class('clustershell') }
 
   it do
     is_expected.to contain_file('/home/rke/.bashrc.d/kubectl.sh')
@@ -18,7 +19,6 @@ shared_examples 'generic rke' do |facts:|
 
   if facts[:os]['family'] == 'RedHat'
     if facts[:os]['release']['major'] == '9'
-      it { is_expected.not_to contain_class('clustershell') }
       it { is_expected.not_to contain_class('network') }
       it { is_expected.to contain_class('profile::nm') }
     else


### PR DESCRIPTION
Clustershell is now available via EPEL9.