### PR TITLE
(dns2.cp) change default route rubins network

### DIFF
--- a/hieradata/node/dns2.cp.lsst.org.yaml
+++ b/hieradata/node/dns2.cp.lsst.org.yaml
@@ -2,7 +2,7 @@
 network::interfaces_hash:
   ens192:  # fqdn
     bootproto: "none"
-    defroute: "no"
+    defroute: "yes"
     ipaddress: "139.229.160.54"
     netmask: "255.255.255.0"
     gateway: "139.229.160.254"
@@ -13,7 +13,7 @@ network::interfaces_hash:
     domain: "cp.lsst.org lsst.cloud lsst.org"
   ens32:  # CTIO backup
     bootproto: "none"
-    defroute: "yes"
+    defroute: "no"
     ipaddress: "192.168.251.241"
     netmask: "255.255.255.0"
     gateway: "192.168.251.1"


### PR DESCRIPTION
as requested on ticket IT-4214, the default route of the dns2 is set to Rubin network instead of rojas net link. (139.229.160.54)