### PR TITLE
fix telegraf package gpgkey error

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -91,7 +91,7 @@ mod 'puppet/scl', git: 'https://github.com/lsst-it/puppet-scl', ref: 'production
 mod 'puppet/selinux', '3.4.1'
 mod 'puppet/ssh_keygen', '5.0.2'
 mod 'puppet/systemd', '3.8.0'
-mod 'puppet/telegraf', '4.2.0'  # requires toml-rb installed on master
+mod 'puppet/telegraf', '4.3.1'  # requires toml-rb installed on master
 mod 'puppet/yum', '6.1.0'
 mod 'qtechnologies/sysstat', '1.2.4'
 mod 'richardc/datacat', '0.6.2'


### PR DESCRIPTION
Resolves this error:

```
Error: Execution of '/bin/dnf -d 0 -e 1 -y install telegraf' returned 1: The GPG keys listed for the "InfluxData Repository - AlmaLinux 8" repository are already installed but they are not correct for this package.
Check that the correct key URLs are configured for this repository.. Failing package is: telegraf-1.25.1-1.x86_64
 GPG Keys are configured as: https://repos.influxdata.com/influxdb.key
Error: GPG check FAILED
Error: /Stage[main]/Telegraf::Install/Package[telegraf]/ensure: change from 'purged' to 'present' failed: Execution of '/bin/dnf -d 0 -e 1 -y install telegraf' returned 1: The GPG keys listed for the "InfluxData Repository - AlmaLinux 8" repository are already installed but they are not correct for this package.
Check that the correct key URLs are configured for this repository.. Failing package is: telegraf-1.25.1-1.x86_64
 GPG Keys are configured as: https://repos.influxdata.com/influxdb.key
Error: GPG check FAILED
Notice: /Stage[main]/Telegraf::Config/File[/etc/telegraf/telegraf.conf]: Dependency Package[telegraf] has failures: true
```