### PR TITLE
fix "Node.js 12 actions are deprecated." warning to gha logs

### DIFF
--- a/.github/workflows/librarian_puppet.yaml
+++ b/.github/workflows/librarian_puppet.yaml
@@ -9,7 +9,7 @@ jobs:
   librarian_puppet:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/markdownlint.yaml
+++ b/.github/workflows/markdownlint.yaml
@@ -9,7 +9,7 @@ jobs:
   markdownlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Run mdl
         uses: actionshub/markdownlint@main

--- a/.github/workflows/rake_checks.yaml
+++ b/.github/workflows/rake_checks.yaml
@@ -11,7 +11,7 @@ jobs:
       group: Default Larger Runners
       labels: ubuntu-latest-16-cores
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -9,7 +9,7 @@ jobs:
   shellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@master

--- a/.github/workflows/yamllint.yaml
+++ b/.github/workflows/yamllint.yaml
@@ -9,7 +9,7 @@ jobs:
   yamllint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Run yamllint
         uses: bewuethr/yamllint-action@v1


### PR DESCRIPTION
To resolve this warning in the gha out put:

```
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
```