### PR TITLE
(proflie::core::sysctl::rp_filter) add 'all' & 'default' to dev list

### DIFF
--- a/site/profile/manifests/core/sysctl/rp_filter.pp
+++ b/site/profile/manifests/core/sysctl/rp_filter.pp
@@ -14,11 +14,12 @@ class profile::core::sysctl::rp_filter (
     default => 0
   }
 
-  $facts['networking']['interfaces'].each |String $dev, Hash $conf| {
+  $interfaces = ['all', 'default'] + fact('networking.interfaces').keys
+  $interfaces.each |String $i| {
     # E.g., p2p1.360 -> p2p1/360
-    $_dev = regsubst($dev, /\./, '/', 'G')
+    $sysctl_dev = regsubst($i, /\./, '/', 'G')
 
-    sysctl::value { "net.ipv4.conf.${_dev}.rp_filter":
+    sysctl::value { "net.ipv4.conf.${sysctl_dev}.rp_filter":
       target => $file,
       value  => $v,
     }

--- a/spec/classes/core/sysctl/rp_filter_spec.rb
+++ b/spec/classes/core/sysctl/rp_filter_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'profile::core::sysctl::rp_filter' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:net_int) do
+        {
+          'lo' => {
+            'bindings' => [
+              {
+                'address' => '127.0.0.1',
+                'netmask' => '255.0.0.0',
+                'network' => '127.0.0.0',
+              },
+            ],
+            'ip' => '127.0.0.1',
+            'mtu' => 65_536,
+            'netmask' => '255.0.0.0',
+            'network' => '127.0.0.0',
+          },
+          'p2p1' => {
+            'dhcp' => '1.2.3.4',  # this looks like a bug in facter
+            'mac' => 'a0:36:9f:c7:79:d4',
+            'mtu' => 1500,
+          },
+          'p2p1.2505' => {
+            'dhcp' => '1.2.3.4',
+            'mac' => 'a0:36:9f:c7:79:d4',
+            'mtu' => 1500,
+          },
+        }
+      end
+      let(:facts) do
+        facts.delete(:networking)
+        override_facts(facts, networking: { interfaces: net_int })
+      end
+
+      interfaces = %w[
+        default
+        all
+        lo
+        p2p1
+        p2p1/2505
+      ]
+
+      it { is_expected.to compile.with_all_deps }
+      it { is_expected.to have_sysctl__value_resource_count(interfaces.count) }
+
+      interfaces.each do |int|
+        it { is_expected.to contain_sysctl__value("net.ipv4.conf.#{int}.rp_filter") }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Testing has shown that setting `net.ipv4.conf.p2p1/2505.rp_filter` to
`0` has no effect if `net.ipv4.conf.all.rp_filter` is set to `1`. Thus,
we need to also change the value of `net.ipv4.conf.all.rp_filter` when
modifying the other interfaces. For good measure,
`net.ipv4.conf.default.rp_filter` is also set to match
`net.ipv4.conf.all.rp_filter` to handle any newly created interfaces.