### PR TITLE
(site/tu) enable dhcp static routes for dds subnets

### DIFF
--- a/hieradata/cluster/manke.yaml
+++ b/hieradata/cluster/manke.yaml
@@ -2,8 +2,8 @@
 clustershell::groupmembers:
   manke: {group: "manke", member: "manke[01-10]"}
 cni::plugins::checksum: "f3a841324845ca6bf0d4091b4fc7f97e18a623172158b72fc3fdcdb9d42d2d37"
-cni::plugins::version: "1.2.0"
 cni::plugins::enable: ["macvlan"]
+cni::plugins::version: "1.2.0"
 profile::core::common::manage_powertop: true
 profile::core::ospl::enable_rundir: true
 profile::core::rke::enable_dhcp: true

--- a/hieradata/cluster/pillan.yaml
+++ b/hieradata/cluster/pillan.yaml
@@ -1,9 +1,9 @@
 ---
 clustershell::groupmembers:
   pillan: {group: "pillan", member: "pillan[01-09]"}
-cni::plugins::checksum: "962100bbc4baeaaa5748cdbfce941f756b1531c2eadb290129401498bfac21e7"
+cni::plugins::checksum: "f3a841324845ca6bf0d4091b4fc7f97e18a623172158b72fc3fdcdb9d42d2d37"
 cni::plugins::enable: ["macvlan"]
-cni::plugins::version: "0.9.1"
+cni::plugins::version: "1.2.0"
 profile::core::common::manage_powertop: true
 profile::core::ospl::enable_rundir: true
 profile::core::rke::enable_dhcp: true

--- a/hieradata/cluster/ruka.yaml
+++ b/hieradata/cluster/ruka.yaml
@@ -2,8 +2,8 @@
 clustershell::groupmembers:
   ruka: {group: "ruka", member: "ruka[01-05]"}
 cni::plugins::checksum: "f3a841324845ca6bf0d4091b4fc7f97e18a623172158b72fc3fdcdb9d42d2d37"
-cni::plugins::version: "1.2.0"
 cni::plugins::enable: ["macvlan"]
+cni::plugins::version: "1.2.0"
 profile::core::common::manage_powertop: true
 profile::core::rke::enable_dhcp: true
 profile::core::rke::version: "1.3.12"

--- a/hieradata/site/tu/role/foreman.yaml
+++ b/hieradata/site/tu/role/foreman.yaml
@@ -46,6 +46,9 @@ dhcp::pools:
     range:
       - "140.252.147.24 140.252.147.30"
     search_domains: "%{alias('dhcp::dnsdomain')}"
+    static_routes:
+      - {network: "140.252.147.48", mask: "28", gateway: "140.252.147.17"}
+      - {network: "140.252.147.128", mask: "27", gateway: "140.252.147.17"}
   vlan3070:  # comcam
     network: "140.252.147.32"
     mask: "255.255.255.240"
@@ -60,6 +63,9 @@ dhcp::pools:
     range:
       - "140.252.147.56 140.252.147.62"
     search_domains: "%{alias('dhcp::dnsdomain')}"
+    static_routes:
+      - {network: "140.252.147.16", mask: "28", gateway: "140.252.147.49"}
+      - {network: "140.252.147.128", mask: "27", gateway: "140.252.147.49"}
   vlan3080:  # misc
     network: "140.252.147.64"
     mask: "255.255.255.224"
@@ -81,6 +87,9 @@ dhcp::pools:
     range:
       - "140.252.147.132 140.252.147.158"
     search_domains: "%{alias('dhcp::dnsdomain')}"
+    static_routes:
+      - {network: "140.252.147.16", mask: "28", gateway: "140.252.147.129"}
+      - {network: "140.252.147.48", mask: "28", gateway: "140.252.147.129"}
 sysctl::values::args:
   net.ipv4.conf.all.arp_filter:
     value: 1

--- a/spec/hosts/nodes/pillan01.tu.lsst.org_spec.rb
+++ b/spec/hosts/nodes/pillan01.tu.lsst.org_spec.rb
@@ -41,6 +41,14 @@ describe 'pillan01.tu.lsst.org', :site do
 
       it { is_expected.to compile.with_all_deps }
 
+      it do
+        is_expected.to contain_class('cni::plugins').with(
+          version: '1.2.0',
+          checksum: 'f3a841324845ca6bf0d4091b4fc7f97e18a623172158b72fc3fdcdb9d42d2d37',
+          enable: ['macvlan'],
+        )
+      end
+
       if facts[:os]['release']['major'] == '7'
         it do
           is_expected.to contain_network__interface('bond0').with(

--- a/spec/hosts/roles/foreman_spec.rb
+++ b/spec/hosts/roles/foreman_spec.rb
@@ -98,6 +98,10 @@ describe "#{role} role" do
             mask: '255.255.255.240',
             range: ['140.252.147.24 140.252.147.30'],
             gateway: '140.252.147.17',
+            static_routes: [
+              { 'network' => '140.252.147.48', 'mask' => '28', 'gateway' => '140.252.147.17' },
+              { 'network' => '140.252.147.128', 'mask' => '27', 'gateway' => '140.252.147.17' },
+            ],
           )
         end
 
@@ -116,6 +120,10 @@ describe "#{role} role" do
             mask: '255.255.255.240',
             range: ['140.252.147.56 140.252.147.62'],
             gateway: '140.252.147.49',
+            static_routes: [
+              { 'network' => '140.252.147.16', 'mask' => '28', 'gateway' => '140.252.147.49' },
+              { 'network' => '140.252.147.128', 'mask' => '27', 'gateway' => '140.252.147.49' },
+            ],
           )
         end
 
@@ -129,20 +137,24 @@ describe "#{role} role" do
         end
 
         it do
-          is_expected.to contain_dhcp__pool('vlan3090').with(
-            network: '140.252.147.96',
-            mask: '255.255.255.224',
-            range: ['140.252.147.122 140.252.147.126'],
-            gateway: '140.252.147.97',
-          )
-        end
-
-        it do
           is_expected.to contain_dhcp__pool('vlan3085').with(
             network: '140.252.147.128',
             mask: '255.255.255.224',
             range: ['140.252.147.132 140.252.147.158'],
             gateway: '140.252.147.129',
+            static_routes: [
+              { 'network' => '140.252.147.16', 'mask' => '28', 'gateway' => '140.252.147.129' },
+              { 'network' => '140.252.147.48', 'mask' => '28', 'gateway' => '140.252.147.129' },
+            ],
+          )
+        end
+
+        it do
+          is_expected.to contain_dhcp__pool('vlan3090').with(
+            network: '140.252.147.96',
+            mask: '255.255.255.224',
+            range: ['140.252.147.122 140.252.147.126'],
+            gateway: '140.252.147.97',
           )
         end
 


### PR DESCRIPTION
Note that these bare metal nodes still have static routes configured for dds subnets:

- comcam-archiver.tu.lsst.org
- auxtel-archiver.tu.lsst.org
- comcam-mcm.tu.lsst.org
- love1.tu.lsst.org
- tel-hw1.tu.lsst.org
- auxtel-mcm.tu.lsst.org

It appears that `dhclient` on EL7 does not handle dhcp option 121 by default.