### PR TITLE
(site/tu/role/foreman) reduce laserlab dhcp pool

### DIFF
--- a/hieradata/site/tu/role/foreman.yaml
+++ b/hieradata/site/tu/role/foreman.yaml
@@ -78,7 +78,7 @@ dhcp::pools:
     mask: "255.255.255.224"
     gateway: "140.252.147.97"
     range:
-      - "140.252.147.122 140.252.147.126"
+      - "140.252.147.124 140.252.147.126"
     search_domains: "%{alias('dhcp::dnsdomain')}"
   vlan3085:  # misc-dds
     network: "140.252.147.128"

--- a/spec/hosts/roles/foreman_spec.rb
+++ b/spec/hosts/roles/foreman_spec.rb
@@ -153,7 +153,7 @@ describe "#{role} role" do
           is_expected.to contain_dhcp__pool('vlan3090').with(
             network: '140.252.147.96',
             mask: '255.255.255.224',
-            range: ['140.252.147.122 140.252.147.126'],
+            range: ['140.252.147.124 140.252.147.126'],
             gateway: '140.252.147.97',
           )
         end


### PR DESCRIPTION
The laserlab subnet was running out of assignable IPs. The dhcp pool is being reduced by 2 (to a total of 3 IPs) to make room for new dhcp reservations.